### PR TITLE
Use `BrowserWindow` from events when available

### DIFF
--- a/main.js
+++ b/main.js
@@ -251,7 +251,7 @@ function setupMenu() {
             ]
           }
         ]
-      : [{}]),
+      : []),
     {
       label: "File",
       submenu: [


### PR DESCRIPTION
Fixes a bug where events (like a `MenuItem` click) would use the currently focused window without handling the `null` case.

This uses the `BrowserWindow` instance passed to the event handler and handles the `null` case to avoid errors like this one:
![a screenshot of an error in Advantage Scope](https://user-images.githubusercontent.com/7608555/159190427-cdf31dc7-4c82-408f-afca-2072d9908abf.png)
