### PR TITLE
Fix launch failure when loading an invalid state file.

### DIFF
--- a/src/main/StateTracker.ts
+++ b/src/main/StateTracker.ts
@@ -47,13 +47,8 @@ export default class StateTracker {
           );
         });
       } catch (e) {
-        dialog.showMessageBox({
-          type: "error",
-          title: "Error Loading State",
-          message: "Error Loading State",
-          detail: "Unable to load state. Reverting to default settings.",
-          buttons: ["Close"]
-        });
+        console.error("Unable to load state. Reverting to default settings.", e);
+        fs.copyFileSync(STATE_FILENAME, STATE_FILENAME.slice(0, -5) + "-corrupted.json");
         resetToDefault = true;
       }
     } else {
@@ -62,10 +57,12 @@ export default class StateTracker {
 
     if (resetToDefault) {
       const bounds = screen.getPrimaryDisplay().bounds;
-      state.x = bounds.x + bounds.width / 2 - defaultWidth / 2;
-      state.y = bounds.y + bounds.height / 2 - defaultHeight / 2;
-      state.width = defaultWidth;
-      state.height = defaultHeight;
+      state = {
+        x: bounds.x + bounds.width / 2 - defaultWidth / 2,
+        y: bounds.y + bounds.height / 2 - defaultHeight / 2,
+        width: defaultWidth,
+        height: defaultHeight
+      };
     }
 
     return state;

--- a/src/main/StateTracker.ts
+++ b/src/main/StateTracker.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen } from "electron";
+import { BrowserWindow, screen, dialog } from "electron";
 import fs from "fs";
 import jsonfile from "jsonfile";
 import { STATE_FILENAME } from "./Constants";
@@ -36,15 +36,26 @@ export default class StateTracker {
 
     let resetToDefault = false;
     if (fs.existsSync(STATE_FILENAME)) {
-      state = jsonfile.readFileSync(STATE_FILENAME);
-      resetToDefault = !screen.getAllDisplays().some((display) => {
-        return (
-          state.x >= display.bounds.x &&
-          state.y >= display.bounds.y &&
-          state.x + state.width <= display.bounds.x + display.bounds.width &&
-          state.y + state.height <= display.bounds.y + display.bounds.height
-        );
-      });
+      try {
+        state = jsonfile.readFileSync(STATE_FILENAME);
+        resetToDefault = !screen.getAllDisplays().some((display) => {
+          return (
+            state.x >= display.bounds.x &&
+            state.y >= display.bounds.y &&
+            state.x + state.width <= display.bounds.x + display.bounds.width &&
+            state.y + state.height <= display.bounds.y + display.bounds.height
+          );
+        });
+      } catch (e) {
+        dialog.showMessageBox({
+          type: "error",
+          title: "Error Loading State",
+          message: "Error Loading State",
+          detail: "Unable to load state. Reverting to default settings.",
+          buttons: ["Close"]
+        });
+        resetToDefault = true;
+      }
     } else {
       resetToDefault = true;
     }


### PR DESCRIPTION
Added error handling code when loading state json files. If a error is thrown the file is reverted to default and a error popup box is shown. The application then continues to load using default sate data.

- Resolves and Closes #37 

Few things I am not sure about. Should the potently corrupted state file be saved instead of overwritten by default values? Should a popup error box even be shown because its a recoverable error?
