### PR TITLE
Fix sorting for lowercase values

### DIFF
--- a/src/hub/Sidebar.ts
+++ b/src/hub/Sidebar.ts
@@ -1,7 +1,7 @@
 import { SidebarState } from "../shared/HubState";
 import LogFieldTree from "../shared/log/LogFieldTree";
 import { getMechanismKeys } from "../shared/log/LogUtil";
-import { arraysEqual, setsEqual, smartSort } from "../shared/util";
+import { arraysEqual, setsEqual } from "../shared/util";
 
 export default class Sidebar {
   private SIDEBAR = document.getElementsByClassName("side-bar")[0] as HTMLElement;
@@ -293,6 +293,6 @@ export default class Sidebar {
       if (!this.KNOWN_KEYS.includes(a) && this.KNOWN_KEYS.includes(b)) return -1;
     }
 
-    return smartSort(a, b);
+    return a.localeCompare(b, undefined, { numeric: true });
   }
 }

--- a/src/main/frcDataUtil.ts
+++ b/src/main/frcDataUtil.ts
@@ -13,7 +13,7 @@ import {
   ConfigJoystick_Joystick,
   FRCData
 } from "../shared/FRCData";
-import { checkArrayType, smartSort } from "../shared/util";
+import { checkArrayType } from "../shared/util";
 import { EXTRA_FRC_DATA } from "./Constants";
 
 /** Creates extra FRC data folder and updates README. */
@@ -363,7 +363,7 @@ export function loadFRCData(): FRCData {
   frcData.robots.sort((a, b) => {
     if (a.title == "KitBot") return -1;
     if (b.title == "KitBot") return 1;
-    return smartSort(a.title, b.title);
+    return a.title.localeCompare(b.title, undefined, { numeric: true });
   });
   frcData.joysticks.sort((a, b) => (a.title > b.title ? -1 : b.title > a.title ? 1 : 0));
 

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -123,29 +123,5 @@ export function createUUID(): string {
 
 /** Sorting function that finds numbers at the start and end of strings. */
 export function smartSort(a: string, b: string): number {
-  function getNum(text: string): number | null {
-    for (let i = 0; i < text.length; i += 1) {
-      let num = Number(text.slice(i));
-      if (!isNaN(num)) {
-        return num;
-      }
-    }
-    for (let i = text.length; i > 0; i -= 1) {
-      let num = Number(text.slice(0, i));
-      if (!isNaN(num)) {
-        return num;
-      }
-    }
-    return null;
-  }
-  let aNum = getNum(a);
-  let bNum = getNum(b);
-  if (aNum != null && bNum != null) {
-    return aNum - bNum;
-  } else if (a > b) {
-    return 1;
-  } else if (a < b) {
-    return -1;
-  }
-  return 0;
+  return a.localeCompare(b, undefined, { numeric: true });
 }

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -120,8 +120,3 @@ export function createUUID(): string {
 
   return outString;
 }
-
-/** Sorting function that finds numbers at the start and end of strings. */
-export function smartSort(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { numeric: true });
-}


### PR DESCRIPTION
Update the `smartSort()` function to properly compare lowercase values.

Before:
![before](https://user-images.githubusercontent.com/7608555/217616907-2fffb974-7658-4081-9247-dbe5eb14ee57.png)

After:
![after](https://user-images.githubusercontent.com/7608555/217616912-7a5736f6-26c2-4834-a2de-862d637f0c8d.png)
