### PR TITLE
Fix file assosciations on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "ext": "wpilog",
         "name": "WPILib robot log",
         "description": "WPILib robot log",
-        "mimeType": "application/octet-stream",
+        "mimeType": "application/x-wpilog",
         "role": "Viewer",
         "icon": "icons/app/wpilog-icon"
       },
@@ -88,7 +88,7 @@
         "ext": "rlog",
         "name": "Robot log",
         "description": "Robot log",
-        "mimeType": "application/octet-stream",
+        "mimeType": "application/x-rlog",
         "role": "Viewer",
         "icon": "icons/app/rlog-icon"
       },
@@ -96,7 +96,7 @@
         "ext": "dslog",
         "name": "FRC Driver Station log",
         "description": "FRC Driver Station log",
-        "mimeType": "application/octet-stream",
+        "mimeType": "application/x-dslog",
         "role": "Viewer",
         "icon": "icons/app/dslog-icon"
       },
@@ -104,7 +104,7 @@
         "ext": "dsevents",
         "name": "FRC Driver Station events",
         "description": "FRC Driver Station events",
-        "mimeType": "application/octet-stream",
+        "mimeType": "application/x-dsevents",
         "role": "Viewer",
         "icon": "icons/app/dsevents-icon"
       }


### PR DESCRIPTION
Long story short, AdvantageScope kinda has the tendency to register itself as literally under every single file extension on Linux, luckily usually as the last choice. It's quite annoying. I suspect this is because all files can technically be interpreted as application/octet-stream and it might be being used as a sort of fallback type (but I don't see that documented nor can I figure out what would be responsible for that)? Either way, using extension-specific mime types fixes it, at least on my system.

Idk whether mime types are used on Windows and Mac, so it'd probably be worth testing on there also, and verify nothing broke. 