### PR TITLE
Improve File Import performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "jsonfile": "^6.1.0",
     "ssh2": "^1.14.0",
     "tesseract.js": "^5.0.3",
-    "ytdl-core": "https://github.com/khlevon/node-ytdl-core.git#v4.11.5-patch.2"
+    "ytdl-core": "https://github.com/khlevon/node-ytdl-core.git#v4.11.5-patch.2",
+    "js-sdsl": "^4.4.2"
   },
   "prettier": {
     "printWidth": 120,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-replace": "^5.0.2",
-    "@rollup/plugin-typescript": "11.1.3",
     "@types/chart.js": "^2.9.38",
     "@types/download": "^8.0.2",
     "@types/heatmap.js": "2.0.38",
@@ -51,20 +50,21 @@
     "rollup": "^3.29.2",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-re": "^1.0.7",
+    "rollup-plugin-typescript2": "^0.36.0",
     "simple-statistics": "^7.8.3",
     "three": "^0.156.1",
     "tslib": "^2.6.2",
-    "typescript": "5.2.2"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "check-disk-space": "^3.4.0",
     "download": "^8.0.0",
     "electron-fetch": "^1.9.1",
+    "js-sdsl": "^4.4.2",
     "jsonfile": "^6.1.0",
     "ssh2": "^1.14.0",
     "tesseract.js": "^5.0.3",
-    "ytdl-core": "https://github.com/khlevon/node-ytdl-core.git#v4.11.5-patch.2",
-    "js-sdsl": "^4.4.2"
+    "ytdl-core": "https://github.com/khlevon/node-ytdl-core.git#v4.11.5-patch.2"
   },
   "prettier": {
     "printWidth": 120,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,7 +2,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import replace from "@rollup/plugin-replace";
-import typescript from "@rollup/plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 import fs from "fs";
 import cleanup from "rollup-plugin-cleanup";
 import replaceRegEx from "rollup-plugin-re";
@@ -16,9 +16,10 @@ function bundle(input, output, isMain, external = []) {
       format: isMain ? "cjs" : "es"
     },
     context: "this",
+    treeshake: true,
     external: external,
     plugins: [
-      typescript(),
+      typescript({ check: false, sourcemap: false }),
       nodeResolve(),
       commonjs(),
       cleanup(),

--- a/src/shared/log/LogField.ts
+++ b/src/shared/log/LogField.ts
@@ -10,11 +10,14 @@ import {
   LogValueSetString,
   LogValueSetStringArray
 } from "./LogValueSets";
-
+import { OrderedSet } from "js-sdsl";
+function cmp(x: { timestamp: number; values: number }, y: { timestamp: number; values: number }): number {
+  return x.timestamp - y.timestamp;
+}
 /** A full log field that contains data. */
 export default class LogField {
   private type: LoggableType;
-  private data: LogValueSetAny = { timestamps: [], values: [] };
+  private data: OrderedSet<{ timestamp: number; values: number }> = new OrderedSet([], cmp);
   public structuredType: string | null = null;
   public wpilibType: string | null = null; // Original type from WPILOG & NT4
   public metadataString = "";
@@ -39,42 +42,39 @@ export default class LogField {
 
   /** Returns the full set of ordered timestamps. */
   getTimestamps(): number[] {
-    return this.data.timestamps;
+    return Array.from(this.data, (elem) => elem.timestamp);
+  }
+  getValues(): number[] {
+    return Array.from(this.data, (elem) => elem.values);
   }
 
   /** Clears all data before the provided timestamp. */
   clearBeforeTime(timestamp: number) {
-    while (this.data.timestamps.length >= 2 && this.data.timestamps[1] < timestamp) {
-      this.data.timestamps.shift();
-      this.data.values.shift();
-      this.stripingReference = !this.stripingReference;
-    }
-    if (this.data.timestamps.length > 0 && this.data.timestamps[0] < timestamp) {
-      this.data.timestamps[0] = timestamp;
+    var itr = this.data.begin();
+    while (itr.isAccessible) {
+      if (itr.pointer.timestamp >= timestamp) {
+        break;
+      }
+      this.data.eraseElementByIterator(itr);
+      itr.next();
     }
   }
 
   /** Returns the values in the specified timestamp range. */
   getRange(start: number, end: number): LogValueSetAny {
-    let timestamps: number[];
-    let values: any[];
+    var timestamps = [];
+    var values = [];
 
-    let startValueIndex = this.data.timestamps.findIndex((x) => x > start);
-    if (startValueIndex === -1) {
-      startValueIndex = this.data.timestamps.length - 1;
-    } else if (startValueIndex !== 0) {
-      startValueIndex -= 1;
+    var itr = this.data.reverseUpperBound({ timestamp: start, values: 0 });
+    while (itr.isAccessible()) {
+      if (itr.pointer.timestamp > end) {
+        break;
+      }
+      timestamps.push(itr.pointer.timestamp);
+      values.push(itr.pointer.values);
+      itr.next();
     }
 
-    let endValueIndex = this.data.timestamps.findIndex((x) => x >= end);
-    if (endValueIndex === -1 || endValueIndex === this.data.timestamps.length - 1) {
-      // Extend to end of timestamps
-      timestamps = this.data.timestamps.slice(startValueIndex);
-      values = this.data.values.slice(startValueIndex);
-    } else {
-      timestamps = this.data.timestamps.slice(startValueIndex, endValueIndex + 1);
-      values = this.data.values.slice(startValueIndex, endValueIndex + 1);
-    }
     return { timestamps: timestamps, values: values };
   }
 
@@ -112,45 +112,73 @@ export default class LogField {
   getStringArray(start: number, end: number): LogValueSetStringArray | undefined {
     if (this.type === LoggableType.StringArray) return this.getRange(start, end);
   }
+  // private findIndex(func: any)
 
   /** Inserts a new value at the correct index. */
   private putData(timestamp: number, value: any) {
+    // return
     if (value === null) return;
 
     // Find position to insert based on timestamp
-    let insertIndex: number;
-    if (this.data.timestamps.length > 0 && timestamp > this.data.timestamps[this.data.timestamps.length - 1]) {
-      // There's a good chance this data is at the end of the log, so check that first
-      insertIndex = this.data.timestamps.length;
+    // let insertIndex: number;
+    // // this.data.rEnd().
+    // if (this.data.length > 0 && timestamp > this.data.timestamps[this.data.timestamps.length - 1]) {
+    //   // There's a good chance this data is at the end of the log, so check that first
+    //   insertIndex = this.data.timestamps.length;
+    // } else {
+    //   // Adding in the middle, find where to insert it
+    //   let alreadyExists = false;
+    //   insertIndex =
+    //     this.data.timestamps.findLastIndex((x) => {
+    //       if (alreadyExists) return;
+    //       if (x === timestamp) alreadyExists = true;
+    //       return x < timestamp;
+    //     }) + 1;
+    //   if (alreadyExists) {
+    //     this.data.values[this.data.timestamps.indexOf(timestamp)] = value;
+    //     return;
+    //   }
+    // }
+    // if (insertIndex >= 0) {
+    //   console.log("Looking for past:" + value);
+    // }
+    //find insert point if set overwrite it with new data
+    // if not
+    // check element behind
+    // if that element is not equal set the value
+    // else do nothing
+    // this.data.end();
+    var record = { timestamp: timestamp, values: value };
+    this.data.insert(record);
+    return;
+    var needle = this.data.find(record);
+
+    if (needle.isAccessible()) {
+      this.data.insert(record);
     } else {
-      // Adding in the middle, find where to insert it
-      let alreadyExists = false;
-      insertIndex =
-        this.data.timestamps.findLastIndex((x) => {
-          if (alreadyExists) return;
-          if (x === timestamp) alreadyExists = true;
-          return x < timestamp;
-        }) + 1;
-      if (alreadyExists) {
-        this.data.values[this.data.timestamps.indexOf(timestamp)] = value;
-        return;
+      var pastElem = this.data.reverseUpperBound(record);
+      if (pastElem.isAccessible()) {
+        if (logValuesEqual(this.type, value, pastElem.pointer)) {
+          this.data.updateKeyByIterator(pastElem, record);
+        } else {
+          this.data.insert(record);
+        }
       }
     }
-
-    // Compare to adjacent values
-    if (insertIndex > 0 && logValuesEqual(this.type, value, this.data.values[insertIndex - 1])) {
-      // Same as the previous value
-    } else if (
-      insertIndex < this.data.values.length &&
-      logValuesEqual(this.type, value, this.data.values[insertIndex])
-    ) {
-      // Same as the next value
-      this.data.timestamps[insertIndex] = timestamp;
-    } else {
-      // New value
-      this.data.timestamps.splice(insertIndex, 0, timestamp);
-      this.data.values.splice(insertIndex, 0, value);
-    }
+    // // Compare to adjacent values
+    // if (insertIndex > 0 && logValuesEqual(this.type, value, this.data.values[insertIndex - 1])) {
+    //   // Same as the previous value
+    // } else if (
+    //   insertIndex < this.data.values.length &&
+    //   logValuesEqual(this.type, value, this.data.values[insertIndex])
+    // ) {
+    //   // Same as the next value
+    //   this.data.timestamps[insertIndex] = timestamp;
+    // } else {
+    //   // New value
+    //   this.data.timestamps.splice(insertIndex, 0, timestamp);
+    //   this.data.values.splice(insertIndex, 0, value);
+    // }
   }
 
   /** Writes a new Raw value to the field. */
@@ -204,10 +232,12 @@ export default class LogField {
 
   /** Returns a serialized version of the data from this field. */
   toSerialized(): any {
+    // console.log(this.getValues());
+    // console.log(this.getTimestamps());
     return {
       type: this.type,
-      timestamps: this.data.timestamps,
-      values: this.data.values,
+      timestamps: this.getTimestamps(),
+      values: this.getValues(),
       structuredType: this.structuredType,
       wpilibType: this.wpilibType,
       metadataString: this.metadataString,
@@ -218,11 +248,9 @@ export default class LogField {
 
   /** Creates a new field based on the data from `toSerialized()` */
   static fromSerialized(serializedData: any) {
+    console.log("ASDFASDFASDFSDAFASD_A_SDF_ASD_FA_SD_F");
     let field = new LogField(serializedData.type);
-    field.data = {
-      timestamps: serializedData.timestamps,
-      values: serializedData.values
-    };
+    field.data = new OrderedSet<{ timestamp: number; values: number }>([], cmp);
     field.structuredType = serializedData.structuredType;
     field.wpilibType = serializedData.wpilibType;
     field.metadataString = serializedData.metadataString;

--- a/src/shared/log/LogField.ts
+++ b/src/shared/log/LogField.ts
@@ -67,7 +67,6 @@ export default class LogField {
 
     var itr = this.data.lowerBound({ timestamp: start, values: 0 });
     while (itr.isAccessible()) {
-      console.log(itr.pointer);
       if (itr.pointer.timestamp > end) {
         break;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    // same as the --compilerOptions flag and the TS_NODE_COMPILER_OPTIONS environment variable
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
@@ -7,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "removeComments": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
I noticed when working with large files Advantage scope tends to take seemly exponential time to import log (WPILOG) files.

This pull request is a very rough/quick and dirty start/working draft to speeding up the ingest process for advantage kit. I replaced the implementation for the ```LogField``` time and value arrays with a Sorted Set from ```js-sdsl```. This PR has gotten basic functionality work but still has some issues with data viewing due to possibly incorrect implementations of ```clearBeforeTime, getRange, toSerialized and fromSerialized.```

With this change I was able to get an improvement of 6x for smaller wpilog files (7mb) and 2x improvement in larger ones (40mb)

I ran the importer though a CPU profiler and it identified a few hot methods taking a large amount of the commutation time, ```putdata, createBlankField```, and ```parseURCLR2```.

I tried to limit any external api changes if at all possible, but would love input on what changes you would be open to, along with any insight on where to look deeper, as It still seems to slow down quite a bit as the files get larger. Maybe writing a parser in C++ would be a approach to getting much better performance? 
