### PR TITLE
PhotonSchema: Add MultiTargetPNPResult

### DIFF
--- a/src/hub/dataSources/schema/CustomSchemas.ts
+++ b/src/hub/dataSources/schema/CustomSchemas.ts
@@ -6,6 +6,6 @@ import REVSchemas from "./REVSchema";
 const CustomSchemas: Map<string, (log: Log, key: string, timestamp: number, value: Uint8Array) => void> = new Map();
 export default CustomSchemas;
 
-CustomSchemas.set("rawBytes", PhotonSchema); // PhotonVision 2023.1.2
+CustomSchemas.set("rawBytes", PhotonSchema); // PhotonVision 2024.3.1
 CustomSchemas.set("URCL", REVSchemas.parseURCLr1);
 CustomSchemas.set("URCLr2_periodic", REVSchemas.parseURCLr2);

--- a/src/hub/dataSources/schema/PhotonSchema.ts
+++ b/src/hub/dataSources/schema/PhotonSchema.ts
@@ -45,7 +45,7 @@ function parsePacket(value: Uint8Array, timestamp: number): PhotonPipelineResult
       offset += 8;
       let y = view.getFloat64(offset);
       offset += 8;
-      minAreaRectCorners.push({ x: x, y: y });
+      minAreaRectCorners.push(new PhotonTargetCorner(x, y));
     }
 
     const detectedCorners = [];
@@ -56,7 +56,7 @@ function parsePacket(value: Uint8Array, timestamp: number): PhotonPipelineResult
       offset += 8;
       let y = view.getFloat64(offset);
       offset += 8;
-      detectedCorners.push({ x: x, y: y });
+      detectedCorners.push(new PhotonTargetCorner(x, y));
     }
 
     result.targets.push({
@@ -131,8 +131,10 @@ function parseTransform3d(view: DataView, offset: number): Transform3d {
 }
 
 class PhotonTargetCorner {
-  x: number = 0;
-  y: number = 0;
+  constructor(
+    readonly x: number,
+    readonly y: number
+  ) {}
 }
 
 type Transform3d = [number, number, number, number, number, number, number];


### PR DESCRIPTION
This exposes the data in the `multiTagResult` section of the PhotonVision packet.

This has been tested against PhotonVision 2024.3.1.

<img width="1117" alt="screenshot of plot of PNP reprojection errors" src="https://github.com/Mechanical-Advantage/AdvantageScope/assets/128854/d6587c8f-19b5-4701-9ecc-1cd36f70e549">
