### PR TITLE
Switch WPILib Linux distribution to directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,14 +419,15 @@ jobs:
       - name: Build documentation
         run: npm run docs:build-embed
       - name: Build app
-        run: npx electron-builder build --publish never --${{ matrix.arch }} -l AppImage
+        run: npx electron-builder build --publish never --${{ matrix.arch }} -l dir
         env:
           ASCOPE_DISTRIBUTOR: WPILIB
           NODE_OPTIONS: --max-old-space-size=4096
       - name: Prepare artifact
         run: |
-          mv dist/AdvantageScope*.AppImage "AdvantageScope (WPILib).AppImage"
-          zip advantagescope-wpilib-linux-${{ matrix.arch }}.zip "AdvantageScope (WPILib).AppImage"
+          cd dist/linux*
+          zip ../../advantagescope-wpilib-linux-${{ matrix.arch }}.zip ./*
+          cd ../..
       - name: Upload development artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,6 +426,7 @@ jobs:
       - name: Prepare artifact
         run: |
           cd dist/linux*
+          mv advantagescope advantagescope-wpilib
           zip ../../advantagescope-wpilib-linux-${{ matrix.arch }}.zip ./*
           cd ../..
       - name: Upload development artifact


### PR DESCRIPTION
Replaces AppImage builds and matches the setup on Windows.