### PR TITLE
Warn about fixed length Photon arrays instead of throwing

### DIFF
--- a/src/shared/log/PhotonStructDecoder.ts
+++ b/src/shared/log/PhotonStructDecoder.ts
@@ -67,7 +67,8 @@ export default class PhotonStructDecoder {
         if (arrayLengthStr === "?") {
           isArray = true; // VLA
         } else {
-          throw new Error("Fixed length arrays are unimplemented");
+          console.warn("Fixed length arrays are unimplemented");
+          return false;
         }
       } else {
         // Normal value
@@ -75,7 +76,8 @@ export default class PhotonStructDecoder {
       }
 
       if (isOptional && isArray) {
-        throw Error("Can't be optional AND array?");
+        console.warn("Can't be optional AND array?");
+        return false;
       }
 
       // Create schema


### PR DESCRIPTION
Fixed length arrays are supported by non-Photon structs, which still need to be compiled by PhotonStructDecoder. This isn't an actual issue unless a Photon struct tries to use a struct with an unsupported array. Returning false just indicates that the schema cannot be compiled or used in parent Photon schemas.

Fixes #273