### PR TITLE
Made it possible to Make Mechanisms on YZ Axis

### DIFF
--- a/src/hub/controllers/ThreeDimensionController.ts
+++ b/src/hub/controllers/ThreeDimensionController.ts
@@ -322,7 +322,7 @@ export default class ThreeDimensionController implements TabController {
             }
 
             case "mechanism": {
-              let state = getMechanismState(window.log, child.logKey, time!);
+              let state = getMechanismState(window.log, child.logKey, time!, child.options.axis);
               if (state !== null) {
                 mechanisms.push(state);
               }

--- a/src/hub/controllers/ThreeDimensionController_Config.ts
+++ b/src/hub/controllers/ThreeDimensionController_Config.ts
@@ -197,7 +197,17 @@ const ThreeDimensionController_Config: SourceListConfig = {
       color: "#888888",
       sourceTypes: ["Mechanism2d"],
       showDocs: true,
-      options: [],
+      options: [
+        {
+          key: "axis",
+          display: "Axis",
+          showInTypeName: true,
+          values: [
+            { key: "x", display: "XZ axis" },
+            { key: "y", display: "YZ axis" }
+          ]
+        }
+      ],
       childOf: "robot"
     },
     {

--- a/src/shared/log/LogUtil.ts
+++ b/src/shared/log/LogUtil.ts
@@ -471,6 +471,7 @@ export type MechanismState = {
   backgroundColor: string;
   dimensions: [number, number];
   lines: MechanismLine[];
+  axis: string;
 };
 
 export type MechanismLine = {
@@ -480,7 +481,7 @@ export type MechanismLine = {
   weight: number;
 };
 
-export function getMechanismState(log: Log, key: string, time: number): MechanismState | null {
+export function getMechanismState(log: Log, key: string, time: number, axis: string = "x"): MechanismState | null {
   // Get general config
   let backgroundColor = getOrDefault(log, key + "/backgroundColor", LoggableType.String, time, null);
   let dimensions = getOrDefault(log, key + "/dims", LoggableType.NumberArray, time, null);
@@ -565,7 +566,8 @@ export function getMechanismState(log: Log, key: string, time: number): Mechanis
   return {
     backgroundColor: backgroundColor,
     dimensions: dimensions,
-    lines: lines
+    lines: lines,
+    axis: axis
   };
 }
 
@@ -587,7 +589,8 @@ export function mergeMechanismStates(states: MechanismState[]): MechanismState {
   return {
     backgroundColor: states[0].backgroundColor,
     dimensions: [newWidth, newHeight],
-    lines: lines
+    lines: lines,
+    axis: states[0].axis
   };
 }
 

--- a/src/shared/renderers/threeDimension/objectManagers/RobotManager.ts
+++ b/src/shared/renderers/threeDimension/objectManagers/RobotManager.ts
@@ -476,11 +476,12 @@ export default class RobotManager extends ObjectManager<
 
         // Update length
         const newScale = new THREE.Vector3(
-          length,
-          line.weight * this.MECHANISM_WIDTH_PER_WEIGHT,
+          object.mechanism.axis == "x" ? length : line.weight * this.MECHANISM_WIDTH_PER_WEIGHT,
+          object.mechanism.axis == "x" ? line.weight * this.MECHANISM_WIDTH_PER_WEIGHT : length,
           line.weight * this.MECHANISM_WIDTH_PER_WEIGHT
         );
-        const newTranslation = new THREE.Vector3(length / 2, 0, 0);
+        const newTranslation =
+          object.mechanism.axis == "x" ? new THREE.Vector3(length / 2, 0, 0) : new THREE.Vector3(0, length / 2, 0);
         if (!newScale.equals(meshEntry.scale) || !newTranslation.equals(meshEntry.translation)) {
           meshEntry.geometry.translate(-meshEntry.translation.x, -meshEntry.translation.y, -meshEntry.translation.z);
           meshEntry.geometry.scale(1 / meshEntry.scale.x, 1 / meshEntry.scale.y, 1 / meshEntry.scale.z);
@@ -503,9 +504,13 @@ export default class RobotManager extends ObjectManager<
               this.dummyRobotPose.rotation.setFromQuaternion(rotation3dToQuaternion(robotPose.rotation));
               this.dummyRobotPose.position.set(...robotPose.translation);
 
-              this.dummyUserPose.position.set(line.start[0] - object.mechanism!.dimensions[0] / 2, 0, line.start[1]);
-              this.dummyUserPose.rotation.set(0, -angle, 0);
-
+              if (object.mechanism?.axis == "x") {
+                this.dummyUserPose.position.set(line.start[0] - object.mechanism!.dimensions[0] / 2, 0, line.start[1]);
+                this.dummyUserPose.rotation.set(0, -angle, 0);
+              } else {
+                this.dummyUserPose.position.set(0, line.start[0] - object.mechanism!.dimensions[0] / 2, line.start[1]);
+                this.dummyUserPose.rotation.set(angle, 0, 0);
+              }
               return {
                 translation: this.dummyUserPose.getWorldPosition(new THREE.Vector3()).toArray(),
                 rotation: quaternionToRotation3d(this.dummyUserPose.getWorldQuaternion(new THREE.Quaternion()))


### PR DESCRIPTION
Our team has a climb mechanism to the side of the robot, and we didn't want to go through the hassle of restructuring our CAD to be able to simulate our actual robot model. I decided to mod advantagescope to allow for swapping the axis a mechanism is displayed on. This probably should be instead handled by a rotation2d or smth, but this was easier to do.

https://github.com/user-attachments/assets/1ecdd489-b469-43a1-acd9-5cf73b7c3c1f

