### PR TITLE
Stop AdvantageScope from occasionally freezing on deploy

### DIFF
--- a/src/shared/log/LogField.ts
+++ b/src/shared/log/LogField.ts
@@ -54,10 +54,10 @@ export default class LogField {
       const value = this.data.values[i];
 
       // If there is more than 1 timestamps and if it occurs before the given timestamp, remove it (don't include it in the new array).
-      if ((this.data.timestamps.length >= 2) && (this.data.timestamps[1] < clearTimestamp)) {
+      if (this.data.timestamps.length >= 2 && this.data.timestamps[1] < clearTimestamp) {
         this.stripingReference = !this.stripingReference;
         continue;
-      };
+      }
 
       newTimestamps.push(timestamp);
       newValues.push(value);

--- a/src/shared/log/LogField.ts
+++ b/src/shared/log/LogField.ts
@@ -45,15 +45,31 @@ export default class LogField {
   }
 
   /** Clears all data before the provided timestamp. */
-  clearBeforeTime(timestamp: number) {
-    while (this.data.timestamps.length >= 2 && this.data.timestamps[1] < timestamp) {
-      this.data.timestamps.shift();
-      this.data.values.shift();
-      this.stripingReference = !this.stripingReference;
+  clearBeforeTime(clearTimestamp: number) {
+    const newTimestamps = [];
+    const newValues = [];
+
+    for (let i = 0; i < this.data.timestamps.length; i++) {
+      const timestamp = this.data.timestamps[i];
+      const value = this.data.values[i];
+
+      // If there is more than 1 timestamps and if it occurs before the given timestamp, remove it (don't include it in the new array).
+      if ((this.data.timestamps.length >= 2) && (this.data.timestamps[1] < clearTimestamp)) {
+        this.stripingReference = !this.stripingReference;
+        continue;
+      };
+
+      newTimestamps.push(timestamp);
+      newValues.push(value);
     }
-    if (this.data.timestamps.length > 0 && this.data.timestamps[0] < timestamp) {
-      this.data.timestamps[0] = timestamp;
+
+    // If there are any left over timestamps, reassign the first timestamp to the given timestamp?
+    if (newTimestamps.length > 0 && newTimestamps[0] < clearTimestamp) {
+      newTimestamps[0] = clearTimestamp;
     }
+
+    this.data.timestamps = newTimestamps;
+    this.data.values = newValues;
   }
 
   /** Returns the values in the specified timestamp range.

--- a/src/shared/renderers/ThreeDimensionRendererImpl.ts
+++ b/src/shared/renderers/ThreeDimensionRendererImpl.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import { CSS2DRenderer } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import WorkerManager from "../../hub/WorkerManager";
 import {
+  AdvantageScopeAssets,
   Config3dField,
   Config3d_Rotation,
   DEFAULT_DRIVER_STATIONS,
@@ -118,7 +119,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
   private lastDevicePixelRatio: number | null = null;
   private lastIsDark: boolean | null = null;
   private lastCommandString: string = "";
-  private lastAssetsString: string = "";
+  private lastAssets: AdvantageScopeAssets | null = null;
   private lastFieldTitle: string = "";
   private keysPressed: Set<string> = new Set();
 
@@ -538,7 +539,10 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
     let commandString = JSON.stringify(command);
     let assetsString = JSON.stringify(window.assets);
     let isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    let newAssets = assetsString !== this.lastAssetsString;
+    let newAssets = assetsString !== JSON.stringify(this.lastAssets);
+    let newFieldAssets = JSON.stringify(window.assets?.field3ds) !== JSON.stringify(this.lastAssets?.field3ds);
+    let newRobotAssets = JSON.stringify(window.assets?.robots) !== JSON.stringify(this.lastAssets?.robots);
+
     if (
       this.renderer.domElement.clientWidth !== this.lastWidth ||
       this.renderer.domElement.clientHeight !== this.lastHeight ||
@@ -554,7 +558,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
       this.lastDevicePixelRatio = window.devicePixelRatio;
       this.lastIsDark = isDark;
       this.lastCommandString = commandString;
-      this.lastAssetsString = assetsString;
+      this.lastAssets = window.assets;
       this.shouldRender = true;
     }
 
@@ -601,7 +605,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
     }
 
     // Update field
-    if (fieldTitle !== this.lastFieldTitle || newAssets) {
+    if (fieldTitle !== this.lastFieldTitle || newFieldAssets) {
       this.shouldLoadNewField = true;
 
       // Reset camera if switching between axis and non-axis or if using DS camera
@@ -731,7 +735,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
       } else {
         entry.active = true;
       }
-      if (newAssets && (entry.type === "robot" || entry.type === "ghost")) {
+      if (newRobotAssets && (entry.type === "robot" || entry.type === "ghost")) {
         (entry.manager as RobotManager).newAssets();
       }
       entry.manager.setObjectData(object);

--- a/src/shared/renderers/ThreeDimensionRendererImpl.ts
+++ b/src/shared/renderers/ThreeDimensionRendererImpl.ts
@@ -3,7 +3,6 @@ import * as THREE from "three";
 import { CSS2DRenderer } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import WorkerManager from "../../hub/WorkerManager";
 import {
-  AdvantageScopeAssets,
   Config3dField,
   Config3d_Rotation,
   DEFAULT_DRIVER_STATIONS,
@@ -119,7 +118,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
   private lastDevicePixelRatio: number | null = null;
   private lastIsDark: boolean | null = null;
   private lastCommandString: string = "";
-  private lastAssets: AdvantageScopeAssets | null = null;
+  private lastAssetsString: string = "";
   private lastFieldTitle: string = "";
   private keysPressed: Set<string> = new Set();
 
@@ -539,10 +538,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
     let commandString = JSON.stringify(command);
     let assetsString = JSON.stringify(window.assets);
     let isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    let newAssets = assetsString !== JSON.stringify(this.lastAssets);
-    let newFieldAssets = JSON.stringify(window.assets?.field3ds) !== JSON.stringify(this.lastAssets?.field3ds);
-    let newRobotAssets = JSON.stringify(window.assets?.robots) !== JSON.stringify(this.lastAssets?.robots);
-
+    let newAssets = assetsString !== this.lastAssetsString;
     if (
       this.renderer.domElement.clientWidth !== this.lastWidth ||
       this.renderer.domElement.clientHeight !== this.lastHeight ||
@@ -558,7 +554,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
       this.lastDevicePixelRatio = window.devicePixelRatio;
       this.lastIsDark = isDark;
       this.lastCommandString = commandString;
-      this.lastAssets = window.assets;
+      this.lastAssetsString = assetsString;
       this.shouldRender = true;
     }
 
@@ -605,7 +601,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
     }
 
     // Update field
-    if (fieldTitle !== this.lastFieldTitle || newFieldAssets) {
+    if (fieldTitle !== this.lastFieldTitle || newAssets) {
       this.shouldLoadNewField = true;
 
       // Reset camera if switching between axis and non-axis or if using DS camera
@@ -735,7 +731,7 @@ export default class ThreeDimensionRendererImpl implements TabRenderer {
       } else {
         entry.active = true;
       }
-      if (newRobotAssets && (entry.type === "robot" || entry.type === "ghost")) {
+      if (newAssets && (entry.type === "robot" || entry.type === "ghost")) {
         (entry.manager as RobotManager).newAssets();
       }
       entry.manager.setObjectData(object);


### PR DESCRIPTION
* Closes #284 where deploying/simulating robot code causes AdvantageScope to freeze occasionally.
* Apologies for yet another small commit again, but this PR optimizes LogField::clearBeforeTime so that it is not re-indexing the 2 arrays every loop inside the while loop.
* I've been testing this for a few hours, and I am no longer able to recreate the original issue, however, if others could test it out to be sure that would be very appreciated!