### PR TITLE
Mark DogLog fields as not tunable

### DIFF
--- a/src/hub/dataSources/nt4/NT4Tuner.ts
+++ b/src/hub/dataSources/nt4/NT4Tuner.ts
@@ -3,6 +3,8 @@ import LiveDataTuner from "../LiveDataTuner";
 import { NT4_Client } from "./NT4";
 import { AKIT_PREFIX, AKIT_TUNING_PREFIX, WPILOG_PREFIX } from "./NT4Source";
 
+const NON_TUNING_PREFIX = /^\/(?:AdvantageKit|Robot)/;
+
 export default class NT4Tuner implements LiveDataTuner {
   private client: NT4_Client;
   private akitMode: boolean;
@@ -25,7 +27,7 @@ export default class NT4Tuner implements LiveDataTuner {
     const type = window.log.getType(key);
     return (
       (type === LoggableType.Number || type === LoggableType.Boolean) &&
-      !remoteKey.startsWith(AKIT_PREFIX) &&
+      !NON_TUNING_PREFIX.test(remoteKey) &&
       !window.log.isGenerated(key)
     );
   }

--- a/src/hub/dataSources/nt4/NT4Tuner.ts
+++ b/src/hub/dataSources/nt4/NT4Tuner.ts
@@ -23,25 +23,12 @@ export default class NT4Tuner implements LiveDataTuner {
   isTunable(key: string): boolean {
     const remoteKey = this.getRemoteKey(key);
     const type = window.log.getType(key);
-
-    // Only numbers and booleans can be tuned
-    if (type !== LoggableType.Number && type !== LoggableType.Boolean) {
-      return false;
-    }
-
-    if (window.log.isGenerated(key)) {
-      return false;
-    }
-
-    if (remoteKey.startsWith(AKIT_PREFIX)) {
-      return true;
-    }
-
-    if (window.log.getField("NT:/Robot/DogLog/Options")) {
-      return !remoteKey.startsWith("/Robot");
-    }
-
-    return true;
+    return (
+      (type === LoggableType.Number || type === LoggableType.Boolean) &&
+      !remoteKey.startsWith(AKIT_PREFIX) &&
+      (window.log.getField("NT:/Robot/DogLog/Options") === null || !remoteKey.startsWith("/Robot")) &&
+      !window.log.isGenerated(key)
+    );
   }
 
   publish(key: string, value: number | boolean): void {


### PR DESCRIPTION
This updates the `isTunable()` logic to exclude fields starting with `/Robot`, in addition to `/AdvantageKit`. DogLog uses `/Robot` as the top-level prefix for logged values, and the `/Tunable` prefix for tunable ones. So, this helps hide readonly DogLog fields from tuning mode.