### PR TITLE
Add right click menu to allow user to copy field name/path to clipboard

### DIFF
--- a/src/hub/Sidebar.ts
+++ b/src/hub/Sidebar.ts
@@ -611,16 +611,16 @@ export default class Sidebar {
     }
 
     // Right-click context menu for copying field paths
-    {
-      label.addEventListener("contextmenu", (event) => {
-        event.preventDefault();
-        window.sendMainMessage("ask-open-sidebar-context-menu", {
-          title: title,
-          fullTitle: fullTitle,
-          position: [event.clientX, event.clientY]
-        });
+    let mouseDownInfo: [number, number, number, number] | null = null;
+    label.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+      mouseDownInfo = null;
+      window.sendMainMessage("ask-open-sidebar-context-menu", {
+        title: title,
+        fullTitle: fullTitle,
+        position: [event.clientX, event.clientY]
       });
-    }
+    });
 
     // Full key fields
     if (field.fullKey !== null) {
@@ -651,7 +651,6 @@ export default class Sidebar {
             this.selectGroupClearCallbacks.forEach((callback) => callback());
           }
         };
-        let mouseDownInfo: [number, number, number, number] | null = null;
         label.addEventListener("mousedown", (event) => {
           mouseDownInfo = [event.clientX, event.clientY, event.offsetX, event.offsetY];
         });

--- a/src/hub/Sidebar.ts
+++ b/src/hub/Sidebar.ts
@@ -614,71 +614,11 @@ export default class Sidebar {
     {
       label.addEventListener("contextmenu", (event) => {
         event.preventDefault();
-
-        // Remove any existing context menu
-        let existingMenu = document.querySelector(".field-context-menu");
-        if (existingMenu) {
-          existingMenu.remove();
-        }
-
-        // Create context menu
-        let contextMenu = document.createElement("div");
-        contextMenu.className = "field-context-menu";
-        contextMenu.style.position = "fixed";
-        contextMenu.style.left = event.clientX + "px";
-        contextMenu.style.top = event.clientY + "px";
-        contextMenu.style.background = window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? "#2d2d2d"
-          : "#ffffff";
-        contextMenu.style.border =
-          "1px solid " + (window.matchMedia("(prefers-color-scheme: dark)").matches ? "#555" : "#ccc");
-        contextMenu.style.borderRadius = "4px";
-        contextMenu.style.padding = "4px 0";
-        contextMenu.style.zIndex = "10000";
-        contextMenu.style.minWidth = "200px";
-        contextMenu.style.boxShadow = "0 2px 8px rgba(0,0,0,0.2)";
-
-        let createCopyToClipboardMenuItem = (text: string, copyText: string) => {
-          let item = document.createElement("div");
-          item.className = "field-context-menu-item";
-          item.style.padding = "8px 16px";
-          item.style.cursor = "pointer";
-          item.style.fontSize = "13px";
-          item.innerText = text;
-          item.addEventListener("mouseenter", () => {
-            item.style.background = window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "rgba(255, 255, 255, 0.1)"
-              : "rgba(0, 0, 0, 0.05)";
-          });
-          item.addEventListener("mouseleave", () => {
-            item.style.background = "transparent";
-          });
-          item.addEventListener("click", () => {
-            navigator.clipboard.writeText(copyText).catch((error) => {
-              console.error("Failed to copy to clipboard:", error);
-            });
-            contextMenu.remove();
-          });
-          return item;
-        };
-
-        // Create menu items
-        contextMenu.appendChild(createCopyToClipboardMenuItem(`Copy "${title}" to clipboard`, title));
-        contextMenu.appendChild(createCopyToClipboardMenuItem(`Copy "${fullTitle}" to clipboard`, fullTitle));
-        document.body.appendChild(contextMenu);
-
-        // Close menu when clicking elsewhere
-        let closeMenu = (e: Event) => {
-          if (!contextMenu.contains(e.target as Node)) {
-            contextMenu.remove();
-            document.removeEventListener("click", closeMenu);
-            document.removeEventListener("contextmenu", closeMenu);
-          }
-        };
-        setTimeout(() => {
-          document.addEventListener("click", closeMenu);
-          document.addEventListener("contextmenu", closeMenu);
-        }, 0);
+        window.sendMainMessage("ask-open-sidebar-context-menu", {
+          title: title,
+          fullTitle: fullTitle,
+          position: [event.clientX, event.clientY]
+        });
       });
     }
 

--- a/src/hub/Sidebar.ts
+++ b/src/hub/Sidebar.ts
@@ -610,6 +610,78 @@ export default class Sidebar {
       }
     }
 
+    // Right-click context menu for copying field paths
+    {
+      label.addEventListener("contextmenu", (event) => {
+        event.preventDefault();
+
+        // Remove any existing context menu
+        let existingMenu = document.querySelector(".field-context-menu");
+        if (existingMenu) {
+          existingMenu.remove();
+        }
+
+        // Create context menu
+        let contextMenu = document.createElement("div");
+        contextMenu.className = "field-context-menu";
+        contextMenu.style.position = "fixed";
+        contextMenu.style.left = event.clientX + "px";
+        contextMenu.style.top = event.clientY + "px";
+        contextMenu.style.background = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "#2d2d2d"
+          : "#ffffff";
+        contextMenu.style.border =
+          "1px solid " + (window.matchMedia("(prefers-color-scheme: dark)").matches ? "#555" : "#ccc");
+        contextMenu.style.borderRadius = "4px";
+        contextMenu.style.padding = "4px 0";
+        contextMenu.style.zIndex = "10000";
+        contextMenu.style.minWidth = "200px";
+        contextMenu.style.boxShadow = "0 2px 8px rgba(0,0,0,0.2)";
+
+        let createCopyToClipboardMenuItem = (text: string, copyText: string) => {
+          let item = document.createElement("div");
+          item.className = "field-context-menu-item";
+          item.style.padding = "8px 16px";
+          item.style.cursor = "pointer";
+          item.style.fontSize = "13px";
+          item.innerText = text;
+          item.addEventListener("mouseenter", () => {
+            item.style.background = window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "rgba(255, 255, 255, 0.1)"
+              : "rgba(0, 0, 0, 0.05)";
+          });
+          item.addEventListener("mouseleave", () => {
+            item.style.background = "transparent";
+          });
+          item.addEventListener("click", () => {
+            navigator.clipboard.writeText(copyText).catch((error) => {
+              console.error("Failed to copy to clipboard:", error);
+            });
+            contextMenu.remove();
+          });
+          return item;
+        };
+
+        // Create menu items
+        contextMenu.appendChild(createCopyToClipboardMenuItem(`Copy "${title}" to clipboard`, title));
+        contextMenu.appendChild(createCopyToClipboardMenuItem(`Copy "${fullTitle}" to clipboard`, fullTitle));
+        document.body.appendChild(contextMenu);
+
+        // Close menu when clicking elsewhere
+        let closeMenu = (e: Event) => {
+          if (!contextMenu.contains(e.target as Node)) {
+            contextMenu.remove();
+            document.removeEventListener("click", closeMenu);
+            document.removeEventListener("contextmenu", closeMenu);
+          }
+        };
+        setTimeout(() => {
+          document.addEventListener("click", closeMenu);
+          document.addEventListener("contextmenu", closeMenu);
+        }, 0);
+      });
+    }
+
     // Full key fields
     if (field.fullKey !== null) {
       // Dragging support

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -550,6 +550,31 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
       shell.openExternal(message.data);
       break;
 
+    case "ask-open-sidebar-context-menu":
+      const fieldCopyMenu = new Menu();
+      fieldCopyMenu.append(
+        new MenuItem({
+          label: `Copy "${message.data.title}" to clipboard`,
+          click() {
+            clipboard.writeText(message.data.title);
+          }
+        })
+      );
+      fieldCopyMenu.append(
+        new MenuItem({
+          label: `Copy "${message.data.fullTitle}" to clipboard`,
+          click() {
+            clipboard.writeText(message.data.fullTitle);
+          }
+        })
+      );
+      fieldCopyMenu.popup({
+        window: window,
+        x: Math.round(message.data.position[0]),
+        y: Math.round(message.data.position[1])
+      });
+      break;
+    
     case "open-app-menu":
     case "close-app-menu":
       {

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -574,7 +574,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
         y: Math.round(message.data.position[1])
       });
       break;
-    
+
     case "open-app-menu":
     case "close-app-menu":
       {

--- a/src/main/lite/main.ts
+++ b/src/main/lite/main.ts
@@ -342,6 +342,10 @@ async function handleHubMessage(message: NamedMessage) {
     case "open-link":
       window.open(message.data, "_blank");
       break;
+    
+    case "ask-open-sidebar-context-menu":
+      // Sidebar context menu is currently not implemented in the Lite version since the only current options require HTTPS APIs (navigator.clipboard APIs).
+      break;
 
     case "open-app-menu":
       {

--- a/src/main/lite/main.ts
+++ b/src/main/lite/main.ts
@@ -342,7 +342,7 @@ async function handleHubMessage(message: NamedMessage) {
     case "open-link":
       window.open(message.data, "_blank");
       break;
-    
+
     case "ask-open-sidebar-context-menu":
       // Sidebar context menu is currently not implemented in the Lite version since the only current options require HTTPS APIs (navigator.clipboard APIs).
       break;


### PR DESCRIPTION
While doing log analysis, I frequently find myself having to dictate field paths into my scripts. This PR adds a right-click context menu to each field in the sidebar which allows the user to copy either just the field name or the full field path to clipboard.

Please let me know if there are any changes you'd like me to make. Also, I've already 👍 [the BSD license issue](https://github.com/Mechanical-Advantage/AdvantageScope/issues/374).

Screenshots:
![Screenshot 2025-07-09 222546](https://github.com/user-attachments/assets/f0c622a8-50e0-47d3-be9f-b91f77344178)

![Screenshot 2025-07-09 223351](https://github.com/user-attachments/assets/1714c00e-5634-4d13-a82b-9b784cf993eb)
