### PR TITLE
fix emscripten 4.0.7+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.74
+          version: 4.0.12
       - name: Install Node.js dependencies
         run: npm ci
         env:
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.74
+          version: 4.0.12
       - name: Install Node.js dependencies
         run: npm ci
         env:
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.74
+          version: 4.0.12
       - name: Install Node.js dependencies
         run: npm ci
         env:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To install Node.js dependencies, run:
 npm install
 ```
 
-[Emscripten](https://emscripten.org) 3.1.74 also needs to be installed (instructions [here](https://emscripten.org/docs/getting_started/downloads.html)).
+[Emscripten](https://emscripten.org) 4.0.12 also needs to be installed (instructions [here](https://emscripten.org/docs/getting_started/downloads.html)).
 
 To build for the current platform, run:
 

--- a/src/hub/dataSources/wpilog/indexer/wpilogIndexer.ts
+++ b/src/hub/dataSources/wpilog/indexer/wpilogIndexer.ts
@@ -35,12 +35,7 @@ var Module: {
   onRuntimeInitialized(): void;
   _malloc(size: number): number;
   _run(buffer: number, bufferSize: number): number;
-  HEAP8: Int8Array;
-  HEAP16: Int16Array;
-  HEAP32: Int32Array;
-  HEAPF32: Float32Array;
   HEAPF64: Float64Array;
   HEAPU8: Uint8Array;
-  HEAPU16: Uint16Array;
   HEAPU32: Uint32Array;
 };

--- a/wasmCompile.mjs
+++ b/wasmCompile.mjs
@@ -51,7 +51,7 @@ try {
       outPath = "'bundles/hub$wpilogIndexer.js' ";
     }
     exec(
-      `emcc ${inPath} -o ${outPath} -sEXPORTED_FUNCTIONS=_run,_malloc -sALLOW_MEMORY_GROWTH -sMAXIMUM_MEMORY=4294967296 -O3`,
+      `emcc ${inPath} -o ${outPath} -sEXPORTED_FUNCTIONS=_run,_malloc -sALLOW_MEMORY_GROWTH -sMAXIMUM_MEMORY=4294967296 -O3 -sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAPF64,HEAPU32`,
       (error, stdout, stderr) => {
         console.log(stdout);
         console.error(stderr);

--- a/wasmCompile.mjs
+++ b/wasmCompile.mjs
@@ -8,7 +8,7 @@
 import { exec } from "child_process";
 import fs from "fs";
 
-const EMSCRIPTEN_VERSION = "3.1.74";
+const EMSCRIPTEN_VERSION = "4.0.12";
 
 try {
   await new Promise(async (resolve, reject) => {
@@ -51,7 +51,7 @@ try {
       outPath = "'bundles/hub$wpilogIndexer.js' ";
     }
     exec(
-      `emcc ${inPath} -o ${outPath} -sEXPORTED_FUNCTIONS=_run,_malloc -sALLOW_MEMORY_GROWTH -sMAXIMUM_MEMORY=4294967296 -O3 -sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAPF64,HEAPU32`,
+      `emcc ${inPath} -o ${outPath} -sEXPORTED_FUNCTIONS=_run,_malloc -sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAPF64,HEAPU32 -sALLOW_MEMORY_GROWTH -sMAXIMUM_MEMORY=4294967296 -O3`,
       (error, stdout, stderr) => {
         console.log(stdout);
         console.error(stderr);


### PR DESCRIPTION
emscripen 4.0.7 no longer exports Heap8, HeapU8, etc by default
https://github.com/emscripten-core/emscripten/pull/24079