### PR TITLE
Fix documentation for expected CSV array format

### DIFF
--- a/docs/docs/overview/log-files/index.md
+++ b/docs/docs/overview/log-files/index.md
@@ -57,7 +57,7 @@ CSV column names must be either "Timestamp, Key, Value" or "Timestamp, (Key), (K
 - **Booleans:** `true` or `false`
 - **Strings:** `"(value)"`
   - Example: `"Hello world"`
-- **Arrays:** `[(value);(value);(value)]`
-  - Example: `[1;2;3]`
+- **Arrays:** `[(value); (value); (value)]`
+  - Example: `[1; 2; 3]`
 - **Bytes:** hexadecimal, separated by `-`
   - Example: `4d-41-36-33-32-38`


### PR DESCRIPTION
Minor fix to follow up on #410.

Array elements have spaces between the trailing semicolon and the beginning of the value.
https://github.com/Mechanical-Advantage/AdvantageScope/blob/cfbe94a5f2bfcc81f9851499d84df29d6da3aca0/src/shared/log/LogUtil.ts#L141