### PR TITLE
Remove repetitive Pose2d fields in FTC Dashboard live mode

### DIFF
--- a/src/hub/dataSources/ftcdashboard/FTCDashboardSource.ts
+++ b/src/hub/dataSources/ftcdashboard/FTCDashboardSource.ts
@@ -146,6 +146,7 @@ export default class FTCDashboardSource extends LiveDataSource implements LiveDa
 
       // Search for poses in the telemetry by parsing lines ending with x, y, heading, and heading (deg)
       let label = name.split(" ").slice(0, -1).join(" ");
+
       if (name.endsWith(" x") || name === "x") {
         if (!foundPoses.has(label)) {
           foundPoses.set(label, { translation: [Units.convert(Number(data), "inches", "meters"), 0], rotation: 0 });
@@ -157,8 +158,9 @@ export default class FTCDashboardSource extends LiveDataSource implements LiveDa
           });
         }
 
-        return;
+        continue;
       }
+
       if (name.endsWith(" y") || name === "y") {
         if (!foundPoses.has(label)) {
           foundPoses.set(label, { translation: [0, Units.convert(Number(data), "inches", "meters")], rotation: 0 });
@@ -170,8 +172,9 @@ export default class FTCDashboardSource extends LiveDataSource implements LiveDa
           });
         }
 
-        return;
+        continue;
       }
+
       if (name.endsWith(" heading") || name === "heading") {
         if (!foundPoses.has(label)) {
           foundPoses.set(label, { translation: [0, 0], rotation: Number(data) });
@@ -180,8 +183,9 @@ export default class FTCDashboardSource extends LiveDataSource implements LiveDa
           foundPoses.set(label, <Pose2d>{ translation: cur.translation, rotation: Number(data) });
         }
 
-        return;
+        continue;
       }
+
       if (name.endsWith(" heading (deg)") || name === "heading (deg)") {
         if (!foundPoses.has(label)) {
           foundPoses.set(label, { translation: [0, 0], rotation: Units.convert(Number(data), "degrees", "radians") });
@@ -193,7 +197,7 @@ export default class FTCDashboardSource extends LiveDataSource implements LiveDa
           });
         }
 
-        return;
+        continue;
       }
 
       switch (typeof data) {


### PR DESCRIPTION
When connected to the FTC Dashboard, currently AdvantageScope reads for fields ending in " x", " y", or " heading", and then creates a Pose2d object based on that ending in " Pose". Seeing individual X, Y, and heading alongside the pose is very inefficient. A better solution would be to drop the fields that make up a Pose2d, and name the Pose2d simply by whatever the first part of the fields is.

The current experience is:
 - The user publishes "Pose x", "Pose y", and "Pose heading"
 - AdvantageScope reads these and creates a Pose2d named "Pose pose"
 - All of the fields are displayed, even the individual components.

The proposed change is:
 - The user would publish "Pose x", "Pose y", and "Pose heading".
 - AdvantageScope reads these values, and creates a Pose2d, named "Pose"
 - The Pose is displayed, while the individual components are not.