### PR TITLE
Add Nanosecond Unit

### DIFF
--- a/src/shared/units.ts
+++ b/src/shared/units.ts
@@ -493,6 +493,12 @@ export namespace Units {
         pluralizeSuffix: false,
         names: ["us", "usec", "usecs", "micro", "micros", "microsecond", "microseconds"]
       },
+      nanoseconds: {
+        value: 1000000000,
+        suffix: "ns",
+        pluralizeSuffix: false,
+        names: ["ns", "nsec", "nsecs", "nano", "nanos", "nanosecond", "nanoseconds"]
+      },
       minutes: {
         value: 1 / 60,
         suffix: "min",


### PR DESCRIPTION
Adds support for converting to and from nanoseconds. This is especially useful because in FTC android code, timestamps are often provided by System.nanoTime() in the unit of nanoseconds. This allows the user to publish timestamps in the most precise form available to them while keeping automatic unit conversions.