### PR TITLE
Change "live data discard duration" to number input

### DIFF
--- a/docs/docs/overview/live-sources/index.md
+++ b/docs/docs/overview/live-sources/index.md
@@ -48,4 +48,4 @@ When NetworkTables is used as the live source, the following live modes can be s
 
 ### Discard Live Data
 
-During a live connection, data is stored locally to allow for replay of past data (see "Viewing Live Data" below). To avoid very high memory usage, data is discarded after 20 minutes by default. A shorter period can be selected to reduce memory usage, or "Never" can be selected to store live data indefinitely.
+During a live connection, data is stored locally to allow for replay of past data (see "Viewing Live Data" below). To avoid very high memory usage, data is discarded after 20 minutes by default. Any custom time period (in minutes) can be entered to reduce memory usage, including decimal values for sub-minute precision. Special value: "-1" stores live data indefinitely (never discard).

--- a/src/hub/dataSources/LiveDataSource.ts
+++ b/src/hub/dataSources/LiveDataSource.ts
@@ -46,9 +46,10 @@ export abstract class LiveDataSource {
     if (enableClearData) {
       this.clearDataCallback = setInterval(() => {
         if (this.log && this.timeSupplier) {
-          let liveDiscardSecs = window.preferences?.liveDiscard;
-          if (liveDiscardSecs !== undefined && liveDiscardSecs !== -1) {
-            let minTime = this.timeSupplier() - liveDiscardSecs;
+          let liveDiscardMins = window.preferences?.liveDiscard;
+          if (liveDiscardMins !== undefined && liveDiscardMins !== -1) {
+            // clear old data based on time window
+            let minTime = this.timeSupplier() - liveDiscardMins * 60;
             this.log.clearBeforeTime(Math.max(0, minTime));
           }
         }

--- a/src/hub/dataSources/nt4/NT4Source.ts
+++ b/src/hub/dataSources/nt4/NT4Source.ts
@@ -236,6 +236,9 @@ export default class NT4Source extends LiveDataSource {
           // Data
           if (!this.log || !this.client || topic.name === "") return;
 
+          // Skip data recording if instantaneous discard (optimization)
+          if (window.preferences?.liveDiscard === 0) return;
+
           let key = this.getKeyFromTopic(topic);
           let timestamp = Math.max(timestamp_us, this.log.getTimestampRange()[0]) / 1000000;
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -98,13 +98,20 @@ window.addEventListener("message", (event) => {
           if (FIELD_3D_MODE_BATTERY.value === "standard") field3dModeBattery = "standard";
           if (FIELD_3D_MODE_BATTERY.value === "low-power") field3dModeBattery = "low-power";
 
+          // Validate liveDiscard: must be -1 or >= 0
+          let liveDiscardValue = Number(LIVE_DISCARD.value);
+          if (isNaN(liveDiscardValue) || (liveDiscardValue !== -1 && liveDiscardValue < 0)) {
+            alert("Live discard time must be -1 (never) or greater than or equal to 0");
+            return;
+          }
+
           let newPrefs: Preferences = {
             theme: theme,
             robotAddress: ROBOT_ADDRESS.value,
             remotePath: REMOTE_PATH.value,
             liveMode: oldPrefs.liveMode,
             liveSubscribeMode: liveSubscribeMode,
-            liveDiscard: Number(LIVE_DISCARD.value),
+            liveDiscard: liveDiscardValue,
             publishFilter: PUBLISH_FILTER.value,
             rlogPort: oldPrefs.rlogPort,
             coordinateSystem: coordinateSystem,

--- a/src/shared/Preferences.ts
+++ b/src/shared/Preferences.ts
@@ -37,7 +37,7 @@ export const DEFAULT_PREFS: Preferences = {
   remotePath: "/U/logs",
   liveMode: "nt4",
   liveSubscribeMode: "low-bandwidth",
-  liveDiscard: 1200,
+  liveDiscard: 20,
   publishFilter: "",
   rlogPort: 5800,
   coordinateSystem: "automatic",

--- a/www/preferences.html
+++ b/www/preferences.html
@@ -82,14 +82,9 @@
           </td>
         </tr>
         <tr>
-          <td class="label">Discard Live Data</td>
+          <td class="label">Discard Live Data (minutes)</td>
           <td class="input" tabindex="-1">
-            <select id="liveDiscard">
-              <option value="60">After 1 minute</option>
-              <option value="300">After 5 minutes</option>
-              <option value="1200">After 20 minutes</option>
-              <option value="-1">Never</option>
-            </select>
+            <input type="number" id="liveDiscard" step="0.1" placeholder="Minutes (-1=never)" />
           </td>
         </tr>
         <tr class="hide-lite">


### PR DESCRIPTION
"Live data discard duration" is an input which is a number, and should therefore be a numerical input, not a drop-down menu. I also changed the internal representation of this value from seconds to minutes to match the UI.