### PR TITLE
Fix YouTube downloading on Linux

### DIFF
--- a/docs/docs/tab-reference/video.md
+++ b/docs/docs/tab-reference/video.md
@@ -23,7 +23,7 @@ YouTube and TBA video download may failed unexpectedly due to changes on YouTube
 :::
 
 :::info
-AdvantageScope requires [FFmpeg](https://ffmpeg.org) to process video files. If a valid copy of FFmpeg is not found on your system's PATH, AdvantageScope will prompt to download FFmpeg from the internet when loading a video for the first time.
+AdvantageScope requires [FFmpeg](https://ffmpeg.org) to process video files. If a valid copy of FFmpeg is not found on your system's PATH, AdvantageScope will prompt to download FFmpeg from the internet when loading a video for the first time. Automatic FFmpeg installation is only supported on Windows and macOS; Linux users may need to manually install FFmpeg and add it to the system PATH.
 :::
 
 ## Navigating the Video

--- a/src/main/electron/VideoProcessor.ts
+++ b/src/main/electron/VideoProcessor.ts
@@ -32,18 +32,6 @@ export class VideoProcessor {
       url: "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-darwin-arm64",
       sha256: "a90e3db6a3fd35f6074b013f948b1aa45b31c6375489d39e572bea3f18336584"
     },
-    "linux-x64": {
-      url: "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-linux-x64",
-      sha256: "ed652b2f32e0851d1946894fb8333f5b677c1b2ce6b9d187910a67f8b99da028"
-    },
-    "linux-arm64": {
-      url: "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-linux-arm64",
-      sha256: "237800b37bb65a81ad47871c6c8b7c45c0a3ca62a5b3f9d2a7a9a2dd9a338271"
-    },
-    "linux-armv7l": {
-      url: "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-linux-arm",
-      sha256: "1a9ddc19d0e071b6e1ff6f8f34dc05ec6dd4d8f3e79a649f5a9ec0e8c929c4cb"
-    },
     "win-x64": {
       url: "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-win32-x64",
       sha256: "e9fd5e711debab9d680955fc1e38a2c1160fd280b144476cc3f62bc43ef49db1"
@@ -202,13 +190,14 @@ export class VideoProcessor {
 
   private static async getFFmpegPath(window: BrowserWindow): Promise<string> {
     // Check for AdvantageScope install (user data folder)
+    // Not compatible with Linux due to DNS issues, force a system install
     let ffmpegPath: string;
     if (process.platform === "win32") {
       ffmpegPath = path.join(app.getPath("userData"), "ffmpeg.exe");
     } else {
       ffmpegPath = path.join(app.getPath("userData"), "ffmpeg");
     }
-    if (fs.existsSync(ffmpegPath)) {
+    if (process.platform !== "linux" && fs.existsSync(ffmpegPath)) {
       return ffmpegPath;
     }
 
@@ -232,7 +221,21 @@ export class VideoProcessor {
       return "ffmpeg";
     }
 
-    // Download FFmpeg
+    // Exit immediately on Linux
+    if (process.platform === "linux") {
+      await dialog.showMessageBox(window, {
+        type: "question",
+        title: "Alert",
+        message: "FFmpeg Installation Required",
+        detail: "FFmpeg is required to process videos files. Please install FFmpeg and add to the PATH.",
+        buttons: ["OK"],
+        defaultId: 0,
+        icon: WINDOW_ICON
+      });
+      throw "Failed";
+    }
+
+    // Download FFmpeg on Windows and macOS
     let ffmpegDownloadResponse = await dialog.showMessageBox(window, {
       type: "question",
       title: "Alert",


### PR DESCRIPTION
* Limit resolution to 1080p
* Update `yt-dlp` options for improved reliability
* Apply full HTTP headers to FFmpeg
* Disable AdvantageScope installations on Linux due to DNS issues