### PR TITLE
Fix local video import

### DIFF
--- a/src/main/electron/VideoProcessor.ts
+++ b/src/main/electron/VideoProcessor.ts
@@ -313,8 +313,8 @@ export class VideoProcessor {
       if (uuid in VideoProcessor.processes) VideoProcessor.processes[uuid].kill();
 
       const ffmpegArgs: string[] = [];
-      ffmpegArgs.push("-reconnect", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "5");
       if (httpHeaders) {
+        ffmpegArgs.push("-reconnect", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "5");
         let headersStr = "";
         for (const [key, value] of Object.entries(httpHeaders)) {
           headersStr += `${key}: ${value}\r\n`;


### PR DESCRIPTION
Fixes issue #472 introduced by #452 where local videos could not be opened. 

Only adds `--reconnect` to ffmpeg command if reading from a URL.
