### PR TITLE
Fix video synchronization for Autonomous periods other than 15 seconds.

### DIFF
--- a/src/hub/controllers/VideoController.ts
+++ b/src/hub/controllers/VideoController.ts
@@ -331,7 +331,7 @@ export default class VideoController implements TabController {
       if (this.autoEndFrame <= 0 && data.autoEndFrame > 0 && !this.locked) {
         let autoEndTime: number | null = null;
         let enabledData = getEnabledData(window.log);
-        if (enabledData && enabledData) {
+        if (enabledData) {
           let wasEnabledLastCycle: boolean = false;
           for (let i = 0; i < enabledData.timestamps.length; i++) {
             if (wasEnabledLastCycle && !enabledData.values[i]) {

--- a/src/hub/controllers/VideoController.ts
+++ b/src/hub/controllers/VideoController.ts
@@ -35,7 +35,7 @@ export default class VideoController implements TabController {
   private fps: number | null = null;
   private totalFrames: number | null = null;
   private completedFrames: number | null = null;
-  private matchStartFrame = -1;
+  private autoEndFrame = -1;
 
   private locked: boolean = false;
   private lockedStartLog: number = 0;
@@ -328,24 +328,27 @@ export default class VideoController implements TabController {
       }
 
       // Lock time when match start frame received
-      if (this.matchStartFrame <= 0 && data.matchStartFrame > 0 && !this.locked) {
-        let enabledTime: number | null = null;
+      if (this.autoEndFrame <= 0 && data.autoEndFrame > 0 && !this.locked) {
+        let autoEndTime: number | null = null;
         let enabledData = getEnabledData(window.log);
-        if (enabledData) {
+        if (enabledData && enabledData) {
+          let wasEnabledLastCycle: boolean = false;
           for (let i = 0; i < enabledData.timestamps.length; i++) {
-            if (enabledData.values[i]) {
-              enabledTime = enabledData.timestamps[i];
+            if (wasEnabledLastCycle && !enabledData.values[i]) {
+              autoEndTime = enabledData.timestamps[i];
               break;
             }
+
+            wasEnabledLastCycle = enabledData.values[i];
           }
         }
-        if (enabledTime !== null) {
+        if (autoEndTime !== null) {
           this.playing = false;
           this.locked = true;
-          this.lockedStartLog = enabledTime - (data.matchStartFrame - 1) / this.fps!;
+          this.lockedStartLog = autoEndTime - (data.autoEndFrame - 1) / this.fps!;
         }
       }
-      this.matchStartFrame = data.matchStartFrame;
+      this.autoEndFrame = data.autoEndFrame;
     } else {
       // Start to load new source, reset controls
       this.locked = false;

--- a/src/main/electron/VideoProcessor.ts
+++ b/src/main/electron/VideoProcessor.ts
@@ -340,7 +340,7 @@ export class VideoProcessor {
       let height = 0;
       let durationSecs = 0;
       let completedFrames = 0;
-      let matchStartFrame = -1;
+      let autoEndFrame = -1;
       let timerSample = 0;
       let timerValues: { frame: number; text: string }[] = [];
       let timerStartFound = false;
@@ -462,10 +462,10 @@ export class VideoProcessor {
                   }
                   const results = await Promise.all(jobs);
                   results.forEach((timerText, index) => {
-                    if (matchStartFrame > 0) return;
+                    if (autoEndFrame > 0) return;
                     if (timerText.includes("12")) {
                       let secs12Frame = secs13Frame! + index;
-                      matchStartFrame = Math.round(secs12Frame - fps * 3);
+                      autoEndFrame = Math.round(secs12Frame + fps * 12);
                     }
                   });
                 }
@@ -481,7 +481,7 @@ export class VideoProcessor {
             fps: fps,
             totalFrames: Math.round(durationSecs * fps),
             completedFrames: completedFrames,
-            matchStartFrame: matchStartFrame
+            autoEndFrame: autoEndFrame
           });
         }
       });
@@ -496,7 +496,7 @@ export class VideoProcessor {
             fps: fps,
             totalFrames: completedFrames, // In case original value was inaccurate
             completedFrames: completedFrames,
-            matchStartFrame: matchStartFrame
+            autoEndFrame: autoEndFrame
           });
         } else if (code === 1) {
           if (videoCache === VIDEO_CACHE && fullOutput.includes("No space left on device")) {

--- a/src/main/electron/VideoProcessor.ts
+++ b/src/main/electron/VideoProcessor.ts
@@ -440,32 +440,32 @@ export class VideoProcessor {
                   timerValues.push({ frame: sampleFrame, text: timerText });
                   timerValues.sort((a, b) => a.frame - b.frame);
 
-                  // Search for 13 -> 12 transition
-                  let lastIs13 = false;
-                  let secs13Frame: number | null = null;
+                  // Search for 4 -> 3 transition
+                  let lastIs4 = false;
+                  let secs4Frame: number | null = null;
                   for (let i = 0; i < timerValues.length; i++) {
-                    let is13 = timerValues[i].text.includes("13");
-                    let is12 = !is13 && timerValues[i].text.includes("12");
-                    if (lastIs13 && is12) {
-                      secs13Frame = timerValues[i - 1].frame;
+                    let is4 = timerValues[i].text.includes("04");
+                    let is3 = !is4 && timerValues[i].text.includes("03");
+                    if (lastIs4 && is3) {
+                      secs4Frame = timerValues[i - 1].frame;
                       break;
                     }
-                    lastIs13 = is13;
+                    lastIs4 = is4;
                   }
-                  if (secs13Frame === null) return;
+                  if (secs4Frame === null) return;
                   timerStartFound = true;
 
                   // Find exact frame
                   let jobs: Promise<string>[] = [];
-                  for (let frame = secs13Frame; frame < secs13Frame + fps; frame++) {
+                  for (let frame = secs4Frame; frame < secs4Frame + fps; frame++) {
                     jobs.push(this.readTimerText(cachePath + zfill(frame.toString(), 8) + ".jpg", width, height));
                   }
                   const results = await Promise.all(jobs);
                   results.forEach((timerText, index) => {
                     if (autoEndFrame > 0) return;
-                    if (timerText.includes("12")) {
-                      let secs12Frame = secs13Frame! + index;
-                      autoEndFrame = Math.round(secs12Frame + fps * 12);
+                    if (timerText.includes("03")) {
+                      let secs3Frame = secs4Frame! + index;
+                      autoEndFrame = Math.round(secs3Frame + fps * 3);
                     }
                   });
                 }


### PR DESCRIPTION
This PR attempts to solve the problem with video synchronization caused by assuming that Autonomous periods will always be 15 seconds long (#487 ), finding the frame which is 3 seconds in to the auto, (when the countdown reaches 12,) and offsetting that to find the beginning of Autonomous. 

The first obvious solution is probably just checking if the log is from 2026, and then changing the amount you offset by. However this will have to continue to be updated for every season that has a different length auto mode. Aiming for broad applicability from season to season, this changes the synchronization to *add 12 seconds* rather than *subtracting 3*, and to synchronize based on the end of auto rather than the beginning. This should work always because since we are finding frames from the match timer, the number of seconds displayed will always be the number of seconds left in Autonomous.

After testing, It gets mostly close, however it is ~600 milliseconds off with the log files I tried. This is either an error on my part, or inherent error with using FPS building up over a longer period of time, A potential fix being detecting a smaller number, and shifting by less frames, but I figured that someone else might have some insight.