### PR TITLE
Add Nix flake development support via flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764860630,
+        "narHash": "sha256-CKbZ9pcwFNksPS9ooKEOJ3V2Wr2oFuy2yteGIezerPc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5b4ad5108eb56aab57e678c7e441ee750fdcb68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5b4ad5108eb56aab57e678c7e441ee750fdcb68",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,82 @@
+{
+  description = "AdvantageScope Development Environment";
+
+  inputs = {
+    # Pin to a commit that has Emscripten 4.0.12
+    nixpkgs.url = "github:NixOS/nixpkgs/f5b4ad5108eb56aab57e678c7e441ee750fdcb68";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShells.${system}.default =
+        (pkgs.buildFHSEnv {
+          name = "advantagescope-dev";
+          targetPkgs =
+            pkgs:
+            (with pkgs; [
+              nodejs_22
+              emscripten # locked to 4.0.12
+              python3
+              pkg-config
+              git
+              gcc
+              gnumake
+
+              flatpak-builder
+              flatpak
+              elfutils
+
+              udev
+              alsa-lib
+              vulkan-loader
+              libGL
+              egl-wayland
+              nss
+              nspr
+              atk
+              at-spi2-atk
+              cups
+              libdrm
+              dbus
+              mesa
+              gtk3
+              pango
+              cairo
+              glib
+              libgbm
+              expat
+              libxkbcommon
+              libxcb
+              icu
+              libz
+              openssl
+              nss
+              nspr
+
+              xorg.libX11
+              xorg.libXcomposite
+              xorg.libXdamage
+              xorg.libXext
+              xorg.libXfixes
+              xorg.libXi
+              xorg.libXrender
+              xorg.libXtst
+              xorg.libXrandr
+              xorg.libXcursor
+              xorg.libxcb
+            ]);
+
+          # runScript = "zsh";
+
+          profile = ''
+            export ASCOPE_DISTRIBUTION=FRC6328 
+            export NIXOS_OZONE_WL=1 
+          '';
+        }).env;
+    };
+}


### PR DESCRIPTION
This PR adds a `flake.nix` and `flake.lock` file to support development of AdvantageScope on NixOS via a dev shell FHS environment.

Consequently, this change also allows NixOS users to use AdvantageScope without having to rely on more imperative package managers like snap and flatpak. Instead, they can build from source declarative.

The flake is pinned to a nixpkgs commit that contains Emscripten 4.0.12, and the flake uses Node v22.21.1

The flake has been tested to work in the following ways:
1. `nix develop` enters the development shell 
2. `npm install` properly installs all required packages
3. `npm run build`, `npm run build-linux`, and `npm run fast-build` all work (mostly -- they currently only fail on building the flatpak, but I figure that's OK since the flatpak is built through GitHub CI)
4. `npm start` successfully launches the application. Basic testing of log loading and viewing, including in the 3D field and the Video tab prove successful.

All this was tested on Hyprland with an Nvidia GPU.

Note: A few of the packages loaded by the dev shell may be unnecessary; I just added a bunch of ones common to this kind of application, and then patched the holes. I can try to prune extra ones if it's necessary. 