### PR TITLE
Support meshoptimizer decoder for 3D models

### DIFF
--- a/src/shared/renderers/createGLTFLoader.ts
+++ b/src/shared/renderers/createGLTFLoader.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2021-2026 Littleton Robotics
+// http://github.com/Mechanical-Advantage
+//
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file
+// at the root directory of this project.
+
+import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+/** Creates a GLTFLoader configured with the meshopt decoder. */
+export default function createGLTFLoader(): GLTFLoader {
+  const loader = new GLTFLoader();
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  return loader;
+}

--- a/src/shared/renderers/field3d/objectManagers/RobotManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/RobotManager.ts
@@ -9,7 +9,8 @@ import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2.js";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry.js";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial.js";
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
+import createGLTFLoader from "../../createGLTFLoader";
 import WorkerManager from "../../../../hub/WorkerManager";
 import { AdvantageScopeAssets } from "../../../AdvantageScopeAssets";
 import { rotationSequenceToQuaternion, SwerveState } from "../../../geometry";
@@ -168,7 +169,7 @@ export default class RobotManager extends ObjectManager<
         if (this.isXR) {
           // XR, load models directly
           const urlTransformer: (path: string) => string = (url) => "/asset?path=" + encodeURIComponent(url);
-          const gltfLoader = new GLTFLoader();
+          const gltfLoader = createGLTFLoader();
           Promise.all([
             new Promise((resolve) => {
               gltfLoader.load(urlTransformer(robotConfig.path), resolve);

--- a/src/shared/renderers/field3d/workers/loadField.ts
+++ b/src/shared/renderers/field3d/workers/loadField.ts
@@ -6,8 +6,9 @@
 // at the root directory of this project.
 
 import * as THREE from "three";
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { Config3dField } from "../../../AdvantageScopeAssets";
+import createGLTFLoader from "../../createGLTFLoader";
 import { rotationSequenceToQuaternion } from "../../../geometry";
 import optimizeGeometries from "../OptimizeGeometries";
 import { prepareTransfer } from "./prepareTransfer";
@@ -32,7 +33,7 @@ self.onmessage = (event) => {
   let fieldStagedPieces = new THREE.Object3D();
   let fieldPieces: { [key: string]: THREE.Mesh } = {};
 
-  const gltfLoader = new GLTFLoader();
+  const gltfLoader = createGLTFLoader();
   Promise.all([
     new Promise((resolve) => {
       gltfLoader.load(fieldConfig.path, resolve);

--- a/src/shared/renderers/field3d/workers/loadRobot.ts
+++ b/src/shared/renderers/field3d/workers/loadRobot.ts
@@ -6,8 +6,9 @@
 // at the root directory of this project.
 
 import * as THREE from "three";
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { Config3dRobot } from "../../../AdvantageScopeAssets";
+import createGLTFLoader from "../../createGLTFLoader";
 import { rotationSequenceToQuaternion } from "../../../geometry";
 import optimizeGeometries from "../OptimizeGeometries";
 import { prepareTransfer } from "./prepareTransfer";
@@ -31,7 +32,7 @@ self.onmessage = (event) => {
 
   let meshes: THREE.MeshJSON[][] = [];
 
-  const gltfLoader = new GLTFLoader();
+  const gltfLoader = createGLTFLoader();
   Promise.all([
     new Promise((resolve) => {
       gltfLoader.load(robotConfig.path, resolve);

--- a/src/xrClient/XRRenderer.ts
+++ b/src/xrClient/XRRenderer.ts
@@ -9,7 +9,8 @@ import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2.js";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry.js";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial.js";
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
+import createGLTFLoader from "../shared/renderers/createGLTFLoader";
 import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
 import { FilmPass } from "three/examples/jsm/postprocessing/FilmPass.js";
 import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
@@ -580,7 +581,7 @@ export default class XRRenderer {
         newFieldReady();
       } else {
         this.isFieldLoading = true;
-        const loader = new GLTFLoader();
+        const loader = createGLTFLoader();
         const urlTransformer: (path: string) => string = (url) => "/asset?path=" + encodeURIComponent(url);
         Promise.all([
           new Promise((resolve) => {


### PR DESCRIPTION
Make it so users can import glTF files compressed using [meshoptimizer](https://github.com/zeux/meshoptimizer). Right now trying to do so will silently error when attempting to render the model.