### PR TITLE
Fix icons for Open Logs page in Lite mode

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -268,7 +268,7 @@ function handleMainMessage(message: NamedMessage) {
               img.src = "../icons/download/" + extension + "-icon-linuxwin.png";
               break;
             case "lite":
-              img.src = "icons/" + extension + "-icon.png";
+              img.src = "../icons/" + extension + "-icon.png";
               break;
           }
         }


### PR DESCRIPTION
The icons were being looked up from the wrong folder