### PR TITLE
fix REVLOG parsing OOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@rev-robotics/revlog-converter": "^1.0.3",
+        "@rev-robotics/revlog-converter": "^1.0.5",
         "@types/emscripten": "^1.39.13",
         "@types/ws": "^8.5.13",
         "basic-ftp": "^5.0.5",
@@ -2723,9 +2723,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rev-robotics/revlog-converter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rev-robotics/revlog-converter/-/revlog-converter-1.0.3.tgz",
-      "integrity": "sha512-kmQzTMlA77iuwQcMPGWjGsemRQbb1+XcsKQyca2Q29beYHoPZgfEVuc4Q75DxvD/9F5yQzjPOyCKIAlcvcUYHw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@rev-robotics/revlog-converter/-/revlog-converter-1.0.5.tgz",
+      "integrity": "sha512-YNafG4BgCq0Ksy1ToMOsmlLFYHc4dEOOl96ccW5Jh/eKghOKDU5+aFS0aOStKLlBQfqPpZmflQqjodfqUKBQuw==",
       "license": "BSD-3-Clause",
       "bin": {
         "revlog-converter": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "5.6.3"
   },
   "dependencies": {
-    "@rev-robotics/revlog-converter": "^1.0.3",
+    "@rev-robotics/revlog-converter": "^1.0.5",
     "@types/emscripten": "^1.39.13",
     "@types/ws": "^8.5.13",
     "basic-ftp": "^5.0.5",

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -430,11 +430,13 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
           // REVLOG, convert to WPILOG
           targetCount += 1;
 
-          parseREVLOG(path)
-            .then((wpilogBuffer) => {
-              results[0] = wpilogBuffer;
-              completedCount++;
-              sendIfReady();
+          // put new WPILOG beside original REVLOG
+          let wpilogPath = path.replace(/\.revlog$/i, ".wpilog");
+          parseREVLOG(path, wpilogPath)
+            .then(() => {
+              openPath(wpilogPath, (buffer) => {
+                results[0] = buffer;
+              });
             })
             .catch((err) => {
               errorMessage = err.message;


### PR DESCRIPTION
Fixes https://github.com/Mechanical-Advantage/AdvantageScope/issues/475 by updating to revlog-converter v1.0.5, which chunks parsing and writes back to the disk instead of loading the entire file into memory and parsing it all at once.

Tested with the REVLOG attached at that issue, which causes OOM on AdvantageScope 26.0.1 and loads successfully with this change.