### PR TITLE
Fix lite mode requiring root to be at /

### DIFF
--- a/src/main/lite/main.ts
+++ b/src/main/lite/main.ts
@@ -416,7 +416,7 @@ async function handleHubMessage(message: NamedMessage) {
               {
                 content: `Show Licenses`,
                 callback() {
-                  openPopupWindow("../www/licenses.html", [50, 75], "percent");
+                  openPopupWindow("www/licenses.html", [50, 75], "percent");
                 }
               }
             ];

--- a/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
@@ -11,6 +11,7 @@ import { zfill } from "../../../util";
 import { Field3dRendererCommand_AprilTagObj } from "../../Field3dRenderer";
 import { rotation3dToQuaternion } from "../../Field3dRendererImpl";
 import ObjectManager from "../ObjectManager";
+import { DISTRIBUTION, Distribution } from "../../../buildConstants";
 
 export default class AprilTagManager extends ObjectManager<Field3dRendererCommand_AprilTagObj> {
   private tags: { idStr: string; active: boolean; object: THREE.Mesh }[] = [];
@@ -95,7 +96,8 @@ export default class AprilTagManager extends ObjectManager<Field3dRendererComman
         this.textureLoader.load(
           this.isXR
             ? `/apriltag?family=${object.variant.family}&name=${textureName}`
-            : `../www/textures/apriltag-${object.variant.family}/${textureName}.png`,
+            : DISTRIBUTION == Distribution.Lite ? `www/textures/apriltag-${object.variant.family}/${textureName}.png`
+              : `../www/textures/apriltag-${object.variant.family}/${textureName}.png`,
           (texture) => {
             texture.minFilter = THREE.NearestFilter;
             texture.magFilter = THREE.NearestFilter;

--- a/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
@@ -6,12 +6,12 @@
 // at the root directory of this project.
 
 import * as THREE from "three";
+import { DISTRIBUTION, Distribution } from "../../../buildConstants";
 import { Units } from "../../../units";
 import { zfill } from "../../../util";
 import { Field3dRendererCommand_AprilTagObj } from "../../Field3dRenderer";
 import { rotation3dToQuaternion } from "../../Field3dRendererImpl";
 import ObjectManager from "../ObjectManager";
-import { DISTRIBUTION, Distribution } from "../../../buildConstants";
 
 export default class AprilTagManager extends ObjectManager<Field3dRendererCommand_AprilTagObj> {
   private tags: { idStr: string; active: boolean; object: THREE.Mesh }[] = [];
@@ -96,8 +96,9 @@ export default class AprilTagManager extends ObjectManager<Field3dRendererComman
         this.textureLoader.load(
           this.isXR
             ? `/apriltag?family=${object.variant.family}&name=${textureName}`
-            : DISTRIBUTION == Distribution.Lite ? `www/textures/apriltag-${object.variant.family}/${textureName}.png`
-              : `../www/textures/apriltag-${object.variant.family}/${textureName}.png`,
+            : DISTRIBUTION == Distribution.Lite
+            ? `www/textures/apriltag-${object.variant.family}/${textureName}.png`
+            : `../www/textures/apriltag-${object.variant.family}/${textureName}.png`,
           (texture) => {
             texture.minFilter = THREE.NearestFilter;
             texture.magFilter = THREE.NearestFilter;


### PR DESCRIPTION
These few places used ../www/*, however that's not exactly true, because we're already at /. In most cases this works, however if ascope is being hosted in a subfolder, this breaks.