### PR TITLE
Fix integration behavior for stepped graphs

### DIFF
--- a/src/hub/controllers/LineGraphController.ts
+++ b/src/hub/controllers/LineGraphController.ts
@@ -477,31 +477,26 @@ export default class LineGraphController implements TabController {
 
         // Add AdvantageKit samples
         if (akitTimestamps !== undefined) {
-          switch (fieldItem.type) {
-            case "stepped":
-              // Extra samples wouldn't affect rendering
-              break;
-            case "smooth":
-            case "points":
-              let newData: LogValueSetNumber = { timestamps: [], values: [] };
-              let sourceIndex = 0;
-              let akitIndex = akitTimestamps.findIndex((akitTime) => akitTime >= data!.timestamps[0]);
+          // Only if its needed for rendering intermediate points, or for a filter.
+          if (fieldItem.type !== "stepped" || filter !== LineGraphFilter.None) {
+            let newData: LogValueSetNumber = { timestamps: [], values: [] };
+            let sourceIndex = 0;
+            let akitIndex = akitTimestamps.findIndex((akitTime) => akitTime >= data!.timestamps[0]);
+            while (
+              akitIndex < akitTimestamps.length &&
+              akitTimestamps[akitIndex] <= data!.timestamps[data!.timestamps.length - 1]
+            ) {
               while (
-                akitIndex < akitTimestamps.length &&
-                akitTimestamps[akitIndex] <= data!.timestamps[data!.timestamps.length - 1]
+                sourceIndex < data!.timestamps.length - 1 &&
+                akitTimestamps[akitIndex] >= data!.timestamps[sourceIndex + 1]
               ) {
-                while (
-                  sourceIndex < data!.timestamps.length - 1 &&
-                  akitTimestamps[akitIndex] >= data!.timestamps[sourceIndex + 1]
-                ) {
-                  sourceIndex++;
-                }
-                newData.timestamps.push(akitTimestamps[akitIndex]);
-                newData.values.push(data!.values[sourceIndex]);
-                akitIndex++;
+                sourceIndex++;
               }
-              data = newData;
-              break;
+              newData.timestamps.push(akitTimestamps[akitIndex]);
+              newData.values.push(data!.values[sourceIndex]);
+              akitIndex++;
+            }
+            data = newData;
           }
         }
 


### PR DESCRIPTION
This is a fix for #493.

The issue with the integration is that on a stepped graph, AdvantageScope skips adding intermediate AdvantageKit samples, which means that the trapezoidal integration will be calculated with a very large dt on long straight sections of a graph, resulting in incorrect calculations, causing some trouble at competitions when trying to compare current draw of different subsystems.

Currently AdvantageScope skips these samples because they shouldn't effect a stepped graph, but overlooks that the integration filter requires all of the intermediate samples to be accurate.

A simple solution is to, instead of only adding AdvantageKit samples when the graph is a point or smooth graph, also adding them when any filter is applied.

Below is a comparison from #493's log file, with the new logic in place. I also tested the logic in the normal non-integrated cases, and AdvantageKit samples are properly added.

The [original issue](https://github.com/Mechanical-Advantage/AdvantageScope/issues/493) also includes images of the incorrect behavior to compare with.

### Stepped Graph
<img width="1568" height="766" alt="image" src="https://github.com/user-attachments/assets/b2956015-b556-4c71-98d1-8f23a286a653" />

### Smooth Graph
<img width="1567" height="768" alt="image" src="https://github.com/user-attachments/assets/8f7af221-797e-4906-9cd7-98717363fbb7" />

### Points Graph
<img width="1568" height="760" alt="image" src="https://github.com/user-attachments/assets/afd528a4-6d51-4a08-949a-ae4037fbdd51" />

### Non-Integrated Points Check
<img width="1575" height="763" alt="image" src="https://github.com/user-attachments/assets/c95c2763-1d82-468a-91f6-ea1997772d62" />