### PR TITLE
Fix memory error for REVLOG parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@rev-robotics/revlog-converter": "^1.0.3",
+        "@rev-robotics/revlog-converter": "^1.0.5",
         "@types/emscripten": "^1.39.13",
         "@types/ws": "^8.5.13",
         "basic-ftp": "^5.0.5",
@@ -2723,9 +2723,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rev-robotics/revlog-converter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rev-robotics/revlog-converter/-/revlog-converter-1.0.3.tgz",
-      "integrity": "sha512-kmQzTMlA77iuwQcMPGWjGsemRQbb1+XcsKQyca2Q29beYHoPZgfEVuc4Q75DxvD/9F5yQzjPOyCKIAlcvcUYHw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@rev-robotics/revlog-converter/-/revlog-converter-1.0.5.tgz",
+      "integrity": "sha512-YNafG4BgCq0Ksy1ToMOsmlLFYHc4dEOOl96ccW5Jh/eKghOKDU5+aFS0aOStKLlBQfqPpZmflQqjodfqUKBQuw==",
       "license": "BSD-3-Clause",
       "bin": {
         "revlog-converter": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "5.6.3"
   },
   "dependencies": {
-    "@rev-robotics/revlog-converter": "^1.0.3",
+    "@rev-robotics/revlog-converter": "^1.0.5",
     "@types/emscripten": "^1.39.13",
     "@types/ws": "^8.5.13",
     "basic-ftp": "^5.0.5",

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -45,6 +45,7 @@ import { SourceListConfig, SourceListItemState, SourceListTypeMemory } from "../
 import TabType, { getAllTabTypes, getDefaultTabTitle, getTabAccelerator, getTabIcon } from "../../shared/TabType";
 import { BUILD_DATE, COPYRIGHT, DISTRIBUTION, Distribution } from "../../shared/buildConstants";
 import { Units } from "../../shared/units";
+import { createUUID } from "../../shared/util";
 import { GITHUB_REPOSITORY } from "../github";
 import {
   AKIT_PATH_INPUT,
@@ -288,9 +289,9 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
       {
         // Record opened files
         const uuid: string = message.data.uuid;
-        const path: string = message.data.path;
-        app.addRecentDocument(path);
-        fs.writeFile(AKIT_PATH_OUTPUT, path, () => {});
+        const logPath: string = message.data.path;
+        app.addRecentDocument(logPath);
+        fs.writeFile(AKIT_PATH_OUTPUT, logPath, () => {});
 
         // Send data if all file reads finished
         let completedCount = 0;
@@ -347,13 +348,13 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
             });
           });
         };
-        if (path.endsWith(".dslog")) {
+        if (logPath.endsWith(".dslog")) {
           // DSLog, open DSEvents too
           results = [null, null];
           targetCount += 2;
-          openPath(path, (buffer) => (results[0] = buffer));
-          openPath(path.slice(0, path.length - 5) + "dsevents", (buffer) => (results[1] = buffer));
-        } else if (path.endsWith(".hoot")) {
+          openPath(logPath, (buffer) => (results[0] = buffer));
+          openPath(logPath.slice(0, logPath.length - 5) + "dsevents", (buffer) => (results[1] = buffer));
+        } else if (logPath.endsWith(".hoot")) {
           // Hoot, convert to WPILOG
           targetCount += 1;
 
@@ -403,12 +404,12 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
             completedCount++;
             sendIfReady();
           } else {
-            checkHootIsPro(path)
+            checkHootIsPro(logPath)
               .then((isPro) => {
                 hasHootNonPro = hasHootNonPro || !isPro;
               })
               .finally(() => {
-                convertHoot(path)
+                convertHoot(logPath)
                   .then((wpilogPath) => {
                     openPath(wpilogPath, (buffer) => {
                       results[0] = buffer;
@@ -426,16 +427,17 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
                   });
               });
           }
-        } else if (path.endsWith(".revlog")) {
+        } else if (logPath.endsWith(".revlog")) {
           // REVLOG, convert to WPILOG
           targetCount += 1;
 
-          // put new WPILOG beside original REVLOG
-          let wpilogPath = path.replace(/\.revlog$/i, ".wpilog");
-          parseREVLOG(path, wpilogPath)
+          // Save WPILOG in temporary folder
+          let wpilogPath = path.join(app.getPath("temp"), "revlog_" + createUUID() + ".wpilog");
+          parseREVLOG(logPath, wpilogPath)
             .then(() => {
               openPath(wpilogPath, (buffer) => {
                 results[0] = buffer;
+                fs.rmSync(wpilogPath);
               });
             })
             .catch((err) => {
@@ -443,7 +445,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
               completedCount++;
               sendIfReady();
             });
-        } else if (path.endsWith(".wpilogxz")) {
+        } else if (logPath.endsWith(".wpilogxz")) {
           // Externally compressed WPILOG, decompress
           targetCount += 1;
           if (lzma === null) {
@@ -451,7 +453,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
             completedCount++;
             sendIfReady();
           } else {
-            fs.open(path, "r", (error, file) => {
+            fs.open(logPath, "r", (error, file) => {
               if (error) {
                 completedCount++;
                 sendIfReady();
@@ -487,7 +489,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
         } else {
           // Normal log, open normally
           targetCount += 1;
-          openPath(path, (buffer) => (results[0] = buffer));
+          openPath(logPath, (buffer) => (results[0] = buffer));
         }
       }
       break;

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -430,11 +430,13 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
           // REVLOG, convert to WPILOG
           targetCount += 1;
 
-          parseREVLOG(path)
-            .then((wpilogBuffer) => {
-              results[0] = wpilogBuffer;
-              completedCount++;
-              sendIfReady();
+          // put new WPILOG beside original REVLOG
+          let wpilogPath = path.replace(/\.revlog$/i, ".wpilog");
+          parseREVLOG(path, wpilogPath)
+            .then(() => {
+              openPath(wpilogPath, (buffer) => {
+                results[0] = buffer;
+              });
             })
             .catch((err) => {
               errorMessage = err.message;


### PR DESCRIPTION
Closes #475. Supersedes #501 with a minor change to the logic for creating the temporary WPILOG file.