### PR TITLE
Potato

### DIFF
--- a/src/shared/units.ts
+++ b/src/shared/units.ts
@@ -698,6 +698,12 @@ export namespace Units {
         suffix: "cal",
         pluralizeSuffix: true,
         names: ["cal", "calorie", "calories"]
+      },
+      potato: {
+        value: 1 / 460.24,
+        suffix: "pot",
+        pluralizeSuffix: false,
+        names: ["pot", "potato", "potatoes"]
       }
     }
   };


### PR DESCRIPTION
This was a really difficult decision but I believe it is correct to use the USDA certified 110 cals per potato even if the 100 cals per sweet potato is more convenient. 

“Vegetables.” FDA, U.S. Food and Drug Administration, 1 Jan. 2008, www.fda.gov/media/76882/download. Accessed 30 Apr. 2026.