### PR TITLE
Fix integration of stepped graphs with deduplicated values

### DIFF
--- a/src/hub/controllers/LineGraphController.ts
+++ b/src/hub/controllers/LineGraphController.ts
@@ -528,9 +528,15 @@ export default class LineGraphController implements TabController {
                   startIndex = Math.max(0, i - 1);
                 }
 
-                // Trapezoidal integration
-                integral +=
-                  (data.timestamps[i] - data.timestamps[prevIndex]) * (data.values[i] + data.values[prevIndex]) * 0.5;
+                if (fieldItem.type === "stepped") {
+                  // Rectangle (left-Riemann): value is held constant between samples, so
+                  // dropped consecutive duplicates don't affect the area.
+                  integral += (data.timestamps[i] - data.timestamps[prevIndex]) * data.values[prevIndex];
+                } else {
+                  // Trapezoidal integration
+                  integral +=
+                    (data.timestamps[i] - data.timestamps[prevIndex]) * (data.values[i] + data.values[prevIndex]) * 0.5;
+                }
                 newValues.push(integral);
               }
               data.values = newValues.slice(startIndex);


### PR DESCRIPTION
## Summary

The line graph **Integrate** filter currently uses the trapezoidal rule for all field types, but `LogField.putData` drops consecutive duplicate values when storing samples. For stepped fields this collapses constant runs — e.g. a setpoint held at `5` from `t=0` to `t=1` and then jumping to `10` is stored as `[(0, 5), (1, 10)]` rather than `[(0, 5), (1, 5), (1, 10)]`.

Trapezoidal integration over the deduplicated data linearly interpolates between the two surviving samples and computes `1 × (5 + 10) / 2 = 7.5`, when the true area under the stepped signal is `5 × 1 = 5`.

#504 mitigated this for AdvantageKit logs by re-densifying samples at AKIT-loop timestamps before integration. That works because dense samples make trapezoidal converge to rectangle integration, but it does not help non-AdvantageKit logs (no AKIT timestamp field), which still produce incorrect integrals for stepped fields.

This change uses the integration formula appropriate to each graph's interpolation semantics:

- **Stepped** (`fieldItem.type === "stepped"`): rectangle (left-Riemann) rule. Exact regardless of whether duplicates were stored or dropped.
- **Smooth / points**: unchanged trapezoidal rule. Exact for linearly-interpolated samples.

## Test plan

- [ ] Open a non-AdvantageKit log (plain WPILOG / NetworkTables, no `/Timestamp` AKIT field) containing a stepped numeric field, e.g. a setpoint that holds at 5 for 1 s then jumps to 10 for 1 s. Add it to a line graph axis with the Integrate filter and confirm the integral reaches 5 at `t=1 s` and 15 at `t=2 s` (pre-fix it overshoots, e.g. ~7.5 at `t=1 s`).
- [ ] Open an AdvantageKit log with a stepped integrated field and confirm no regression versus #504's behavior.
- [ ] Confirm a smooth numeric field still integrates via the trapezoidal rule unchanged.
- [ ] Toggle the visible time range to verify `startIndex` slicing still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)