### PR TITLE
Flatten bundle file hierarchy

### DIFF
--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -28,7 +28,7 @@ function bundle(input, isMain, isXRClient, external = []) {
     input: input.map((input) => "src/" + input),
     output: {
       dir: (isLite ? "lite/static/" : "") + "bundles/",
-      chunkFileNames: "chunk/[name].js",
+      chunkFileNames: "[name].js",
       format: isMain ? "cjs" : "es",
       banner: licenseHeader
     },


### PR DESCRIPTION
~~For whatever reason, this fixes an issue where the window just... doesn't pop up at all. Unsure as to the mechanism.~~ Turns out the electron-builder config globs `bundles/*` which means any chunks placed under `chunks` don't get packaged up. The hierarchy can be flattened since `wpilogIndexer.ts` and `wpilogIndexer.js` (from Emscripten) don't actually conflict with each other.