### PR TITLE
Fix AprilTag image paths in Lite

### DIFF
--- a/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/AprilTagManager.ts
@@ -97,7 +97,7 @@ export default class AprilTagManager extends ObjectManager<Field3dRendererComman
           this.isXR
             ? `/apriltag?family=${object.variant.family}&name=${textureName}`
             : DISTRIBUTION == Distribution.Lite
-            ? `www/textures/apriltag-${object.variant.family}/${textureName}.png`
+            ? `textures/apriltag-${object.variant.family}/${textureName}.png`
             : `../www/textures/apriltag-${object.variant.family}/${textureName}.png`,
           (texture) => {
             texture.minFilter = THREE.NearestFilter;


### PR DESCRIPTION
Fix path for AprilTag images in AdvantageScope Lite. Tested with alternative web roots.