### PR TITLE
Fix Electron locale configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
       "enableEmbeddedAsarIntegrityValidation": true,
       "onlyLoadAppFromAsar": true
     },
+    "electronLanguages": [
+      "en-US"
+    ],
     "files": [
       "www/**/*",
       "bundles/**/*",
@@ -197,6 +200,9 @@
       "notarize": false,
       "extendInfo": {
         "CFBundleIconName": "AppIcon",
+        "CFBundleLocalizations": [
+          "en"
+        ],
         "NSLocalNetworkUsageDescription": "AdvantageScope uses the local network to communicate with robots.",
         "NSUpdateSecurityPolicy": {
           "AllowPackages": [


### PR DESCRIPTION
By default, Electron apps includes locales for every language supported by Chromium. Operating systems may therefore select a non-English language that isn't actually supported. This is an issue for RTL languages (e.g. Hebrew, Arabic) since the OS window controls are in the wrong location for AdvantageScope's LTR layout. The fix is to explicitly declare the list of supported languages (English) so that operating system always runs with LTR window controls.