### PR TITLE
Clean up Promise usage and use async/await more

### DIFF
--- a/src/hub/dataSources/csv/csvWorker.ts
+++ b/src/hub/dataSources/csv/csvWorker.ts
@@ -13,7 +13,7 @@ function sendResponse(response: HistoricalDataSource_WorkerResponse) {
   self.postMessage(response);
 }
 
-self.onmessage = async (event) => {
+self.onmessage = (event) => {
   let request: HistoricalDataSource_WorkerRequest = event.data;
   if (request.type !== "start") return;
 

--- a/src/hub/dataSources/dslog/dsLogWorker.ts
+++ b/src/hub/dataSources/dslog/dsLogWorker.ts
@@ -14,7 +14,7 @@ function sendResponse(response: HistoricalDataSource_WorkerResponse) {
   self.postMessage(response);
 }
 
-self.onmessage = async (event) => {
+self.onmessage = (event) => {
   let request: HistoricalDataSource_WorkerRequest = event.data;
   if (request.type !== "start") return;
 

--- a/src/hub/dataSources/rlog/rlogWorker.ts
+++ b/src/hub/dataSources/rlog/rlogWorker.ts
@@ -13,7 +13,7 @@ function sendResponse(response: HistoricalDataSource_WorkerResponse) {
   self.postMessage(response);
 }
 
-self.onmessage = async (event) => {
+self.onmessage = (event) => {
   let request: HistoricalDataSource_WorkerRequest = event.data;
   if (request.type !== "start") return;
 

--- a/src/hub/dataSources/roadrunnerlog/roadRunnerWorker.ts
+++ b/src/hub/dataSources/roadrunnerlog/roadRunnerWorker.ts
@@ -13,7 +13,7 @@ function sendResponse(response: HistoricalDataSource_WorkerResponse) {
   self.postMessage(response);
 }
 
-self.onmessage = async (event) => {
+self.onmessage = (event) => {
   let request: HistoricalDataSource_WorkerRequest = event.data;
   if (request.type !== "start") return;
 

--- a/src/hub/hub.ts
+++ b/src/hub/hub.ts
@@ -960,34 +960,32 @@ async function handleMainMessage(message: NamedMessage) {
       // Load missing fields
       await Promise.all(historicalSources.map((entry) => entry.source.loadAllFields()));
 
-      // Convert to export format
-      WorkerManager.request(
-        "../bundles/exportWorker.js",
-        {
-          options: message.data.options,
-          log: window.log.toSerialized()
-        },
-        (progress: number) => {
-          clearInterval(mockProgressInterval);
-          setLoading(scaleValue(progress, [0, 1], [mockProgress, 1]));
-        }
-      )
-        .then((content) => {
-          window.sendMainMessage("write-export", {
-            path: message.data.path,
-            content: content
-          });
-        })
-        .catch(() => {
-          window.sendMainMessage("error", {
-            title: "Failed to export data",
-            content: "There was a problem while converting to the export format. Please try again."
-          });
-          setLoading(null);
-        })
-        .finally(() => {
-          setExporting(false);
+      try {
+        // Convert to export format
+        const content = await WorkerManager.request(
+          "../bundles/exportWorker.js",
+          {
+            options: message.data.options,
+            log: window.log.toSerialized()
+          },
+          (progress: number) => {
+            clearInterval(mockProgressInterval);
+            setLoading(scaleValue(progress, [0, 1], [mockProgress, 1]));
+          }
+        );
+        window.sendMainMessage("write-export", {
+          path: message.data.path,
+          content: content
         });
+      } catch {
+        window.sendMainMessage("error", {
+          title: "Failed to export data",
+          content: "There was a problem while converting to the export format. Please try again."
+        });
+        setLoading(null);
+      } finally {
+        setExporting(false);
+      }
       break;
 
     case "finish-export":

--- a/src/main/electron/VideoProcessor.ts
+++ b/src/main/electron/VideoProcessor.ts
@@ -266,17 +266,17 @@ export class VideoProcessor {
     // Verify hash
     let hash = crypto
       .createHash("sha256")
-      .update(fs.readFileSync(path.join(folder, filenameTemp)))
+      .update(await fs.promises.readFile(path.join(folder, filenameTemp)))
       .digest("hex");
     if (hash !== downloadInfo.sha256) {
       console.warn("FFmpeg hash violation!");
       console.warn("\tFound: " + hash);
       console.warn("\tExpected: " + downloadInfo.sha256);
-      fs.rmSync(path.join(folder, filenameTemp));
+      await fs.promises.unlink(path.join(folder, filenameTemp));
       throw "Failed";
     }
-    fs.renameSync(path.join(folder, filenameTemp), path.join(folder, filename));
-    fs.chmodSync(path.join(folder, filename), 0o755);
+    await fs.promises.rename(path.join(folder, filenameTemp), path.join(folder, filename));
+    await fs.promises.chmod(path.join(folder, filename), 0o755);
     return ffmpegPath;
   }
 
@@ -571,7 +571,7 @@ export class VideoProcessor {
   }
 
   private static async readTimerText(imagePath: string, width: number, height: number): Promise<string> {
-    const image = fs.readFileSync(imagePath);
+    const image = await fs.promises.readFile(imagePath);
     let result = "";
     for (let i = 0; i < this.TIMER_RECTS.length; i++) {
       let rect = this.TIMER_RECTS[i];

--- a/src/main/electron/XRServer.ts
+++ b/src/main/electron/XRServer.ts
@@ -54,15 +54,21 @@ export namespace XRServer {
           switch (url.pathname) {
             case "/":
               response.writeHead(200, { "Content-Type": "text/html" });
-              response.end(fs.readFileSync(path.join(__dirname, "../www/xrClient.html"), { encoding: "utf-8" }));
+              response.end(
+                await fs.promises.readFile(path.join(__dirname, "../www/xrClient.html"), { encoding: "utf-8" })
+              );
               return;
             case "/index.css":
               response.writeHead(200, { "Content-Type": "text/css" });
-              response.end(fs.readFileSync(path.join(__dirname, "../www/xrClient.css"), { encoding: "utf-8" }));
+              response.end(
+                await fs.promises.readFile(path.join(__dirname, "../www/xrClient.css"), { encoding: "utf-8" })
+              );
               return;
             case "/index.js":
               response.writeHead(200, { "Content-Type": "text/javascript" });
-              response.end(fs.readFileSync(path.join(__dirname, "../bundles/xrClient.js"), { encoding: "utf-8" }));
+              response.end(
+                await fs.promises.readFile(path.join(__dirname, "../bundles/xrClient.js"), { encoding: "utf-8" })
+              );
               return;
             case "/apriltag":
               let family = url.searchParams.get("family");
@@ -75,7 +81,7 @@ export namespace XRServer {
 
               const imgPath = path.join(__dirname, "../www/textures/apriltag-" + family + "/" + name + ".png");
               try {
-                let imgData = fs.readFileSync(imgPath);
+                let imgData = await fs.promises.readFile(imgPath);
                 response.writeHead(200, { "Content-Type": "image/png" });
                 response.end(imgData);
               } catch {
@@ -127,7 +133,7 @@ export namespace XRServer {
 
               // Read file
               response.writeHead(200, { "Content-Type": "application/octet-stream" });
-              response.end(fs.readFileSync(decodeURIComponent(assetPath)));
+              response.end(await fs.promises.readFile(decodeURIComponent(assetPath)));
               return;
           }
         }

--- a/src/main/electron/assetDownloader.ts
+++ b/src/main/electron/assetDownloader.ts
@@ -20,41 +20,38 @@ const SUCCESS_TIMEOUT_MS = 6 * 60 * 60 * 1000; // 6 hours
 let statusText = "No status available.";
 
 /** Updates the local set of automatic assets and retries periodically in case of network issues. */
-export function startAssetDownloadLoop(updateCallback: () => void) {
-  let check: () => void = () => {
-    checkDiskSpace(AUTO_ASSETS)
-      .then((diskSpace) => {
-        if (diskSpace.free / 1e9 < REQUIRED_SPACE_GB) {
-          throw new Error();
-        }
-        getAssetInfo()
-          .then((assetInfo) => {
-            statusText =
-              "Download started at " +
-              new Date().toLocaleTimeString() +
-              ". Please wait a few minutes for the download to complete.";
-            updateLocalAssets(assetInfo)
-              .then(() => {
-                statusText = "All assets downloaded. AdvantageScope will check for updates periodically.";
-                updateCallback();
-                setTimeout(() => check(), SUCCESS_TIMEOUT_MS);
-              })
-              .catch(() => {
-                statusText = "Cannot connect to GitHub. Trying again soon.";
-                setTimeout(() => check(), FAILURE_TIMEOUT_MS);
-              });
-          })
-          .catch(() => {
-            statusText = "Cannot connect to GitHub. Trying again soon.";
-            setTimeout(() => check(), FAILURE_TIMEOUT_MS);
-          });
-      })
-      .catch(() => {
-        statusText = "Not enough disk space. Trying again soon.";
+export async function startAssetDownloadLoop(updateCallback: () => Promise<void>) {
+  let check: () => Promise<void> = async () => {
+    try {
+      const diskSpace = await checkDiskSpace(AUTO_ASSETS);
+      if (diskSpace.free / 1e9 < REQUIRED_SPACE_GB) {
+        throw new Error();
+      }
+    } catch {
+      statusText = "Not enough disk space. Trying again soon.";
+      setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+    }
+    try {
+      const assetInfo = await getAssetInfo();
+      statusText =
+        "Download started at " +
+        new Date().toLocaleTimeString() +
+        ". Please wait a few minutes for the download to complete.";
+      try {
+        updateLocalAssets(assetInfo);
+        statusText = "All assets downloaded. AdvantageScope will check for updates periodically.";
+        await updateCallback();
+        setTimeout(() => check(), SUCCESS_TIMEOUT_MS);
+      } catch {
+        statusText = "Cannot connect to GitHub. Trying again soon.";
         setTimeout(() => check(), FAILURE_TIMEOUT_MS);
-      });
+      }
+    } catch {
+      statusText = "Cannot connect to GitHub. Trying again soon.";
+      setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+    }
   };
-  check();
+  await check();
 }
 
 /** Returns a string for the current status of the download. */
@@ -120,7 +117,7 @@ async function updateLocalAssets(downloadInfo: AssetDownloadInfo[]) {
   );
 
   // Delete old assets
-  fs.readdirSync(AUTO_ASSETS).forEach((folder) => {
+  (await fs.promises.readdir(AUTO_ASSETS)).forEach((folder) => {
     let folderPath = path.join(AUTO_ASSETS, folder);
     if (!downloadInfo.some((assetInfo) => assetInfo.target === folderPath)) {
       fs.rmSync(folderPath, { recursive: true });

--- a/src/main/electron/assetDownloader.ts
+++ b/src/main/electron/assetDownloader.ts
@@ -30,6 +30,7 @@ export async function startAssetDownloadLoop(updateCallback: () => Promise<void>
     } catch {
       statusText = "Not enough disk space. Trying again soon.";
       setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+      return;
     }
     try {
       const assetInfo = await getAssetInfo();
@@ -38,7 +39,7 @@ export async function startAssetDownloadLoop(updateCallback: () => Promise<void>
         new Date().toLocaleTimeString() +
         ". Please wait a few minutes for the download to complete.";
       try {
-        updateLocalAssets(assetInfo);
+        await updateLocalAssets(assetInfo);
         statusText = "All assets downloaded. AdvantageScope will check for updates periodically.";
         await updateCallback();
         setTimeout(() => check(), SUCCESS_TIMEOUT_MS);

--- a/src/main/electron/assetLoader.ts
+++ b/src/main/electron/assetLoader.ts
@@ -38,7 +38,7 @@ export function createAssetFolders() {
 }
 
 /** Loads all current assets (bundled, auto downloaded, and user). */
-export function loadAssets(): AdvantageScopeAssets {
+export async function loadAssets(): Promise<AdvantageScopeAssets> {
   let assets: AdvantageScopeAssets = {
     field2ds: [],
     field3ds: [],
@@ -48,86 +48,89 @@ export function loadAssets(): AdvantageScopeAssets {
   };
 
   // Highest priority is first
-  [getUserAssetsPath(), AUTO_ASSETS, BUNDLED_ASSETS].forEach((parentFolder) => {
-    if (!fs.existsSync(parentFolder)) return;
-    fs.readdirSync(parentFolder, { withFileTypes: true })
-      .sort((a, b) => (a.name < b.name ? 1 : a.name > b.name ? -1 : 0)) // Inverse order so newer versions take priority
-      .forEach((object) => {
-        if (!object.isDirectory() || object.name.startsWith(".")) return;
-        assets.loadFailures.push(object.name); // Assume failure, remove if successful
-        let isField2d = object.name.startsWith("Field2d_");
-        let isField3d = object.name.startsWith("Field3d_");
-        let isRobot = object.name.startsWith("Robot_");
-        let isJoystick = object.name.startsWith("Joystick_");
+  await Promise.all(
+    [getUserAssetsPath(), AUTO_ASSETS, BUNDLED_ASSETS].map(async (parentFolder) => {
+      try {
+        for (const object of (await fs.promises.readdir(parentFolder, { withFileTypes: true })).sort((a, b) =>
+          a.name < b.name ? 1 : a.name > b.name ? -1 : 0
+        )) {
+          // Inverse order so newer versions take priority
+          if (!object.isDirectory() || object.name.startsWith(".")) return;
+          assets.loadFailures.push(object.name); // Assume failure, remove if successful
+          let isField2d = object.name.startsWith("Field2d_");
+          let isField3d = object.name.startsWith("Field3d_");
+          let isRobot = object.name.startsWith("Robot_");
+          let isJoystick = object.name.startsWith("Joystick_");
 
-        let configPath = path.join(parentFolder, object.name, "config.json");
-        if (!fs.existsSync(configPath)) return;
-        let configRaw: unknown;
-        try {
-          configRaw = jsonfile.readFileSync(configPath);
-        } catch {
-          return;
-        }
+          let configPath = path.join(parentFolder, object.name, "config.json");
+          let configRaw: unknown;
+          try {
+            configRaw = await jsonfile.readFile(configPath);
+          } catch {
+            return;
+          }
 
-        if (isField2d) {
-          // ***** 2D FIELD *****
-          let config = parseField2d(configRaw);
-          if (config === "skip") {
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            return;
-          } else if (config === "invalid") {
-            return;
-          }
-          config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
-          if (fs.existsSync(decodeURIComponent(config.path))) {
-            assets.field2ds.push(config);
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-          }
-        } else if (isField3d) {
-          // ***** 3D FIELD *****
-          let config = parseField3d(configRaw);
-          if (config === "skip") {
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            return;
-          } else if (config === "invalid") {
-            return;
-          }
-          config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
-          if (
-            fs.existsSync(decodeURIComponent(config.path)) &&
-            config.gamePieces.every((_, index) =>
-              fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
-            )
-          ) {
-            assets.field3ds.push(config);
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-          }
-        } else if (isRobot) {
-          // ***** 3D ROBOT *****
-          let config = parseRobot(configRaw);
-          if (config === "invalid") return;
-          config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
-          if (
-            fs.existsSync(decodeURIComponent(config.path)) &&
-            config.components.every((_, index) =>
-              fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
-            )
-          ) {
-            assets.robots.push(config);
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-          }
-        } else if (isJoystick) {
-          // ***** JOYSTICK *****
-          let config = parseJoystick(configRaw);
-          if (config === "invalid") return;
-          config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
-          if (fs.existsSync(decodeURIComponent(config.path))) {
-            assets.joysticks.push(config);
-            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+          if (isField2d) {
+            // ***** 2D FIELD *****
+            let config = parseField2d(configRaw);
+            if (config === "skip") {
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+              return;
+            } else if (config === "invalid") {
+              return;
+            }
+            config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
+            if (fs.existsSync(decodeURIComponent(config.path))) {
+              assets.field2ds.push(config);
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            }
+          } else if (isField3d) {
+            // ***** 3D FIELD *****
+            let config = parseField3d(configRaw);
+            if (config === "skip") {
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+              return;
+            } else if (config === "invalid") {
+              return;
+            }
+            config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
+            if (
+              fs.existsSync(decodeURIComponent(config.path)) &&
+              config.gamePieces.every((_, index) =>
+                fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
+              )
+            ) {
+              assets.field3ds.push(config);
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            }
+          } else if (isRobot) {
+            // ***** 3D ROBOT *****
+            let config = parseRobot(configRaw);
+            if (config === "invalid") return;
+            config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
+            if (
+              fs.existsSync(decodeURIComponent(config.path)) &&
+              config.components.every((_, index) =>
+                fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
+              )
+            ) {
+              assets.robots.push(config);
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            }
+          } else if (isJoystick) {
+            // ***** JOYSTICK *****
+            let config = parseJoystick(configRaw);
+            if (config === "invalid") return;
+            config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
+            if (fs.existsSync(decodeURIComponent(config.path))) {
+              assets.joysticks.push(config);
+              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            }
           }
         }
-      });
-  });
+      } catch {}
+    })
+  );
 
   return filterAndSortAssets(assets);
 }

--- a/src/main/electron/assetLoader.ts
+++ b/src/main/electron/assetLoader.ts
@@ -38,7 +38,7 @@ export function createAssetFolders() {
 }
 
 /** Loads all current assets (bundled, auto downloaded, and user). */
-export async function loadAssets(): Promise<AdvantageScopeAssets> {
+export function loadAssets(): AdvantageScopeAssets {
   let assets: AdvantageScopeAssets = {
     field2ds: [],
     field3ds: [],
@@ -48,89 +48,86 @@ export async function loadAssets(): Promise<AdvantageScopeAssets> {
   };
 
   // Highest priority is first
-  await Promise.all(
-    [getUserAssetsPath(), AUTO_ASSETS, BUNDLED_ASSETS].map(async (parentFolder) => {
-      try {
-        for (const object of (await fs.promises.readdir(parentFolder, { withFileTypes: true })).sort((a, b) =>
-          a.name < b.name ? 1 : a.name > b.name ? -1 : 0
-        )) {
-          // Inverse order so newer versions take priority
-          if (!object.isDirectory() || object.name.startsWith(".")) return;
-          assets.loadFailures.push(object.name); // Assume failure, remove if successful
-          let isField2d = object.name.startsWith("Field2d_");
-          let isField3d = object.name.startsWith("Field3d_");
-          let isRobot = object.name.startsWith("Robot_");
-          let isJoystick = object.name.startsWith("Joystick_");
+  [getUserAssetsPath(), AUTO_ASSETS, BUNDLED_ASSETS].forEach((parentFolder) => {
+    if (!fs.existsSync(parentFolder)) return;
+    fs.readdirSync(parentFolder, { withFileTypes: true })
+      .sort((a, b) => (a.name < b.name ? 1 : a.name > b.name ? -1 : 0)) // Inverse order so newer versions take priority
+      .forEach((object) => {
+        if (!object.isDirectory() || object.name.startsWith(".")) return;
+        assets.loadFailures.push(object.name); // Assume failure, remove if successful
+        let isField2d = object.name.startsWith("Field2d_");
+        let isField3d = object.name.startsWith("Field3d_");
+        let isRobot = object.name.startsWith("Robot_");
+        let isJoystick = object.name.startsWith("Joystick_");
 
-          let configPath = path.join(parentFolder, object.name, "config.json");
-          let configRaw: unknown;
-          try {
-            configRaw = await jsonfile.readFile(configPath);
-          } catch {
+        let configPath = path.join(parentFolder, object.name, "config.json");
+        if (!fs.existsSync(configPath)) return;
+        let configRaw: unknown;
+        try {
+          configRaw = jsonfile.readFileSync(configPath);
+        } catch {
+          return;
+        }
+
+        if (isField2d) {
+          // ***** 2D FIELD *****
+          let config = parseField2d(configRaw);
+          if (config === "skip") {
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            return;
+          } else if (config === "invalid") {
             return;
           }
-
-          if (isField2d) {
-            // ***** 2D FIELD *****
-            let config = parseField2d(configRaw);
-            if (config === "skip") {
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-              return;
-            } else if (config === "invalid") {
-              return;
-            }
-            config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
-            if (fs.existsSync(decodeURIComponent(config.path))) {
-              assets.field2ds.push(config);
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            }
-          } else if (isField3d) {
-            // ***** 3D FIELD *****
-            let config = parseField3d(configRaw);
-            if (config === "skip") {
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-              return;
-            } else if (config === "invalid") {
-              return;
-            }
-            config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
-            if (
-              fs.existsSync(decodeURIComponent(config.path)) &&
-              config.gamePieces.every((_, index) =>
-                fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
-              )
-            ) {
-              assets.field3ds.push(config);
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            }
-          } else if (isRobot) {
-            // ***** 3D ROBOT *****
-            let config = parseRobot(configRaw);
-            if (config === "invalid") return;
-            config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
-            if (
-              fs.existsSync(decodeURIComponent(config.path)) &&
-              config.components.every((_, index) =>
-                fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
-              )
-            ) {
-              assets.robots.push(config);
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            }
-          } else if (isJoystick) {
-            // ***** JOYSTICK *****
-            let config = parseJoystick(configRaw);
-            if (config === "invalid") return;
-            config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
-            if (fs.existsSync(decodeURIComponent(config.path))) {
-              assets.joysticks.push(config);
-              assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
-            }
+          config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
+          if (fs.existsSync(decodeURIComponent(config.path))) {
+            assets.field2ds.push(config);
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+          }
+        } else if (isField3d) {
+          // ***** 3D FIELD *****
+          let config = parseField3d(configRaw);
+          if (config === "skip") {
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+            return;
+          } else if (config === "invalid") {
+            return;
+          }
+          config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
+          if (
+            fs.existsSync(decodeURIComponent(config.path)) &&
+            config.gamePieces.every((_, index) =>
+              fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
+            )
+          ) {
+            assets.field3ds.push(config);
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+          }
+        } else if (isRobot) {
+          // ***** 3D ROBOT *****
+          let config = parseRobot(configRaw);
+          if (config === "invalid") return;
+          config.path = encodePath(path.join(parentFolder, object.name, "model.glb"));
+          if (
+            fs.existsSync(decodeURIComponent(config.path)) &&
+            config.components.every((_, index) =>
+              fs.existsSync(decodeURIComponent(config.path).slice(0, -4) + "_" + index.toString() + ".glb")
+            )
+          ) {
+            assets.robots.push(config);
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
+          }
+        } else if (isJoystick) {
+          // ***** JOYSTICK *****
+          let config = parseJoystick(configRaw);
+          if (config === "invalid") return;
+          config.path = encodePath(path.join(parentFolder, object.name, "image.png"));
+          if (fs.existsSync(decodeURIComponent(config.path))) {
+            assets.joysticks.push(config);
+            assets.loadFailures.splice(assets.loadFailures.indexOf(object.name), 1);
           }
         }
-      } catch {}
-    })
-  );
+      });
+  });
 
   return filterAndSortAssets(assets);
 }

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -277,7 +277,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
       });
       let newTypeMemoryStr = JSON.stringify(typeMemory);
       if (originalTypeMemoryStr !== newTypeMemoryStr) {
-        jsonfile.writeFileSync(TYPE_MEMORY_FILENAME, typeMemory);
+        await jsonfile.writeFile(TYPE_MEMORY_FILENAME, typeMemory);
       }
       break;
 
@@ -304,7 +304,7 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
         const uuid: string = message.data.uuid;
         const logPath: string = message.data.path;
         app.addRecentDocument(logPath);
-        fs.writeFile(AKIT_PATH_OUTPUT, logPath, () => {});
+        await fs.promises.writeFile(AKIT_PATH_OUTPUT, logPath);
 
         // Send data if all file reads finished
         let completedCount = 0;
@@ -377,21 +377,17 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
             if (ctreLicensePrompt === null) {
               ctreLicensePrompt = new Promise(async (resolve) => {
                 while (true) {
-                  let response = await new Promise<Electron.MessageBoxReturnValue>((resolve) =>
-                    dialog
-                      .showMessageBox(window, {
-                        type: "question",
-                        title: "Alert",
-                        message: "CTRE License Agreement",
-                        detail:
-                          "Hoot log file decoding requires agreement to CTRE's end user license agreement. Please click the button below to view the full license agreement, then check the box if you agree to the terms.",
-                        checkboxLabel: "I Agree",
-                        buttons: ["View License", "OK"],
-                        defaultId: 1,
-                        icon: WINDOW_ICON
-                      })
-                      .then((response) => resolve(response))
-                  );
+                  let response = await dialog.showMessageBox(window, {
+                    type: "question",
+                    title: "Alert",
+                    message: "CTRE License Agreement",
+                    detail:
+                      "Hoot log file decoding requires agreement to CTRE's end user license agreement. Please click the button below to view the full license agreement, then check the box if you agree to the terms.",
+                    checkboxLabel: "I Agree",
+                    buttons: ["View License", "OK"],
+                    defaultId: 1,
+                    icon: WINDOW_ICON
+                  });
                   if (response.response === 1) {
                     if (response.checkboxChecked) {
                       prefs.ctreLicenseAccepted = true;
@@ -446,18 +442,17 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
 
           // Save WPILOG in temporary folder
           let wpilogPath = path.join(app.getPath("temp"), "revlog_" + createUUID() + ".wpilog");
-          parseREVLOG(logPath, wpilogPath)
-            .then(() => {
-              openPath(wpilogPath, (buffer) => {
-                results[0] = buffer;
-                fs.rmSync(wpilogPath);
-              });
-            })
-            .catch((err) => {
-              errorMessage = err.message;
-              completedCount++;
-              sendIfReady();
+          try {
+            await parseREVLOG(logPath, wpilogPath);
+            openPath(wpilogPath, (buffer) => {
+              results[0] = buffer;
+              fs.rmSync(wpilogPath);
             });
+          } catch (err: any) {
+            errorMessage = err.message;
+            completedCount++;
+            sendIfReady();
+          }
         } else if (logPath.endsWith(".wpilogxz")) {
           // Externally compressed WPILOG, decompress
           targetCount += 1;
@@ -1873,7 +1868,7 @@ function setupMenu() {
           type: "checkbox",
           async click(item) {
             const isCustom = item.checked;
-            let prefs: Preferences = jsonfile.readFileSync(PREFS_FILENAME);
+            let prefs: Preferences = await jsonfile.readFile(PREFS_FILENAME);
             if (isCustom) {
               let result = await dialog.showOpenDialog({
                 title: "Select folder containing custom AdvantageScope assets",
@@ -1886,8 +1881,8 @@ function setupMenu() {
             } else {
               prefs.userAssetsFolder = null;
             }
-            jsonfile.writeFileSync(PREFS_FILENAME, prefs);
-            advantageScopeAssets = loadAssets();
+            await jsonfile.writeFile(PREFS_FILENAME, prefs);
+            advantageScopeAssets = await loadAssets();
             sendAllPreferences();
             sendAssets();
           }
@@ -3450,7 +3445,7 @@ if (process.platform === "linux") {
   }
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   // Check preferences and set theme
   let prefs = DEFAULT_PREFS;
   if (process.platform === "linux") {
@@ -3470,16 +3465,16 @@ app.whenReady().then(() => {
 
   // Load assets
   createAssetFolders();
-  startAssetDownloadLoop(() => {
-    advantageScopeAssets = loadAssets();
+  startAssetDownloadLoop(async () => {
+    advantageScopeAssets = await loadAssets();
     sendAssets();
   });
-  setInterval(() => {
+  setInterval(async () => {
     // Periodically load assets in case they are updated
-    advantageScopeAssets = loadAssets();
+    advantageScopeAssets = await loadAssets();
     sendAssets();
   }, 5000);
-  advantageScopeAssets = loadAssets();
+  advantageScopeAssets = await loadAssets();
 
   // Start owlet download
   startOwletDownloadLoop();

--- a/src/main/electron/main.ts
+++ b/src/main/electron/main.ts
@@ -304,7 +304,8 @@ async function handleHubMessage(window: BrowserWindow, message: NamedMessage) {
         const uuid: string = message.data.uuid;
         const logPath: string = message.data.path;
         app.addRecentDocument(logPath);
-        await fs.promises.writeFile(AKIT_PATH_OUTPUT, logPath);
+        // Writing this file is a supplemental task, so we don't need to block/ensure success
+        fs.writeFile(AKIT_PATH_OUTPUT, logPath, () => {});
 
         // Send data if all file reads finished
         let completedCount = 0;

--- a/src/main/electron/owletDownload.ts
+++ b/src/main/electron/owletDownload.ts
@@ -114,9 +114,7 @@ export async function downloadOwletInternal(target: string, platform: string, st
       // Download if necessary
       if (shouldDownload) {
         // Get list of existing files to delete
-        const existingFiles = await new Promise<string[]>((resolve) =>
-          fs.readdir(target, (_, files) => resolve(files))
-        );
+        const existingFiles = await fs.promises.readdir(target);
         const toDelete = existingFiles.filter((filename) =>
           filename.includes("-C" + downloadVersion.Compliancy.toString())
         );
@@ -129,16 +127,16 @@ export async function downloadOwletInternal(target: string, platform: string, st
         hash.update(fs.readFileSync(path.join(target, tempFilename)));
         const hex = hash.digest("hex");
         if (hex === downloadVersion.Urls[owletPlatform + "-sha1"]) {
-          fs.chmodSync(path.join(target, tempFilename), 0o755);
+          await fs.promises.chmod(path.join(target, tempFilename), 0o755);
 
           // Delete older versions
-          toDelete.forEach((filename) => fs.unlinkSync(path.join(target, filename)));
+          await Promise.all(toDelete.map((filename) => fs.promises.unlink(path.join(target, filename))));
 
           // Move to final location
-          fs.renameSync(path.join(target, tempFilename), path.join(target, filename));
+          await fs.promises.rename(path.join(target, tempFilename), path.join(target, filename));
         } else {
           // Delete temporary file
-          fs.unlinkSync(path.join(target, tempFilename));
+          await fs.promises.unlink(path.join(target, tempFilename));
         }
       }
     }

--- a/src/main/electron/owletDownloadLoop.ts
+++ b/src/main/electron/owletDownloadLoop.ts
@@ -24,32 +24,30 @@ let statusText = "No status available.";
 
 /** Updates the stored copies of owlet and retries periodically in case of network issues */
 export async function startOwletDownloadLoop() {
-  let check: () => void = () => {
-    checkDiskSpace(OWLET_STORAGE)
-      .then((diskSpace) => {
-        if (diskSpace.free / 1e9 < REQUIRED_SPACE_GB) {
-          throw new Error();
-        }
-        downloadOwletInternal(OWLET_STORAGE, getElectronPlatform())
-          .then(() => {
-            statusText = "Owlet is up-to-date. AdvantageScope will check for updates periodically.";
-            setTimeout(() => check(), SUCCESS_TIMEOUT_MS);
-          })
-          .catch(() => {
-            statusText = "Using offline owlet cache. Checking for updates soon.";
-            setTimeout(() => check(), FAILURE_TIMEOUT_MS);
-          });
-      })
-      .catch(() => {
-        statusText = "Not enough disk space. Trying again soon.";
-        setTimeout(() => check(), FAILURE_TIMEOUT_MS);
-      });
+  let check: () => Promise<void> = async () => {
+    try {
+      const diskSpace = await checkDiskSpace(OWLET_STORAGE);
+      if (diskSpace.free / 1e9 < REQUIRED_SPACE_GB) {
+        throw new Error();
+      }
+    } catch {
+      statusText = "Not enough disk space. Trying again soon.";
+      setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+    }
+    try {
+      downloadOwletInternal(OWLET_STORAGE, getElectronPlatform());
+      statusText = "Owlet is up-to-date. AdvantageScope will check for updates periodically.";
+      setTimeout(() => check(), SUCCESS_TIMEOUT_MS);
+    } catch {
+      statusText = "Using offline owlet cache. Checking for updates soon.";
+      setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+    }
   };
 
   try {
     await copyBundledOwlet();
   } catch {}
-  check();
+  await check();
 }
 
 /** Returns a string for the current status of the download. */
@@ -65,9 +63,7 @@ export async function copyBundledOwlet(): Promise<void> {
   }
 
   // Loop through bundled files
-  let bundledFiles = await new Promise<string[]>((resolve) =>
-    fs.readdir(OWLET_BUNDLED_STORAGE, (_, files) => resolve(files))
-  );
+  let bundledFiles = await fs.promises.readdir(OWLET_BUNDLED_STORAGE);
   for (let i = 0; i < bundledFiles.length; i++) {
     let filename = bundledFiles[i];
     let bundledVersion = filename.split("-")[1];
@@ -75,23 +71,19 @@ export async function copyBundledOwlet(): Promise<void> {
 
     // Copy bundled file to storage folder
     let copy = async () => {
-      await new Promise<void>((resolve) => {
-        fs.copyFile(path.join(OWLET_BUNDLED_STORAGE, filename), path.join(OWLET_STORAGE, filename), () => resolve());
-      });
-      fs.chmodSync(path.join(OWLET_STORAGE, filename), 0o755);
+      await fs.promises.copyFile(path.join(OWLET_BUNDLED_STORAGE, filename), path.join(OWLET_STORAGE, filename));
+      await fs.promises.chmod(path.join(OWLET_STORAGE, filename), 0o755);
     };
 
     // Look for stored version with same compliancy
-    let storedFilenames = await new Promise<string[]>((resolve) =>
-      fs.readdir(OWLET_STORAGE, (_, files) => resolve(files))
-    );
+    let storedFilenames = await fs.promises.readdir(OWLET_STORAGE);
     let storedFilename = storedFilenames.find((filename) => getCompliancy(filename) === compliancy);
     if (storedFilename !== undefined) {
       // Existing version found, check if bundled version is newer
       let storedVersion = storedFilename.split("-")[1];
       if (compareVersions(bundledVersion, storedVersion) > 0) {
         // Delete older version
-        fs.unlinkSync(path.join(OWLET_STORAGE, storedFilename));
+        await fs.promises.unlink(path.join(OWLET_STORAGE, storedFilename));
 
         // Copy bundled version
         await copy();

--- a/src/main/electron/owletDownloadLoop.ts
+++ b/src/main/electron/owletDownloadLoop.ts
@@ -33,9 +33,10 @@ export async function startOwletDownloadLoop() {
     } catch {
       statusText = "Not enough disk space. Trying again soon.";
       setTimeout(() => check(), FAILURE_TIMEOUT_MS);
+      return;
     }
     try {
-      downloadOwletInternal(OWLET_STORAGE, getElectronPlatform());
+      await downloadOwletInternal(OWLET_STORAGE, getElectronPlatform());
       statusText = "Owlet is up-to-date. AdvantageScope will check for updates periodically.";
       setTimeout(() => check(), SUCCESS_TIMEOUT_MS);
     } catch {

--- a/src/main/electron/owletInterface.ts
+++ b/src/main/electron/owletInterface.ts
@@ -88,9 +88,7 @@ async function getOwletPath(hootPath: string): Promise<string> {
   }
 
   // Find owlet version for compliancy
-  let owletFilenames = await new Promise<string[]>((resolve) =>
-    fs.readdir(OWLET_STORAGE, (_, files) => resolve(files))
-  );
+  let owletFilenames = await fs.promises.readdir(OWLET_STORAGE);
   owletFilenames = owletFilenames.filter((filename) => filename.startsWith("owlet-"));
   let finalOwletFilename = owletFilenames.find((filename) => filename.includes("-C" + compliancy.toString()));
   if (finalOwletFilename === undefined) {

--- a/src/shared/renderers/field3d/OptimizeGeometries.ts
+++ b/src/shared/renderers/field3d/OptimizeGeometries.ts
@@ -16,7 +16,7 @@ export const STANDARD_MAX_RADIUS = 0.04;
 export const CINEMATIC_MAX_RADIUS = 0.02;
 export const FTC_MULTIPLIER = 0.25; // FTC components are smaller, adjust appropriately to avoid cutting too agressively
 
-export default async function optimizeGeometries(
+export default function optimizeGeometries(
   object: THREE.Object3D,
   mode: "low-power" | "standard" | "cinematic",
   materialSpecular: THREE.Color,
@@ -24,93 +24,91 @@ export default async function optimizeGeometries(
   enableSimplification = true,
   isFTC: boolean = false,
   slicingSize?: number
-): Promise<{
+): {
   normal: THREE.Mesh[];
   transparent: THREE.Mesh[];
   carpet: THREE.Mesh[];
-}> {
-  return new Promise(async (resolve) => {
-    let geometries = getGeometries(object, mode, enableSimplification, isFTC, slicingSize);
+} {
+  let geometries = getGeometries(object, mode, enableSimplification, isFTC, slicingSize);
 
-    let normalMeshes: THREE.Mesh[] = [];
-    let transparentMeshes: THREE.Mesh[] = [];
-    let carpetMeshes: THREE.Mesh[] = [];
-    geometries.normal.forEach((group) => {
-      if (group.length > 0) {
-        let geometry = BufferGeometryUtils.mergeGeometries(group, false);
-        if (geometry !== null) {
-          let mesh = new THREE.Mesh(
-            geometry,
-            new THREE.MeshPhongMaterial({
-              vertexColors: true,
-              side: THREE.DoubleSide,
-              specular: materialSpecular,
-              shininess: materialShininess
-            })
-          );
-          normalMeshes.push(mesh);
-          if (mode === "cinematic") {
-            mesh.castShadow = true;
-            mesh.receiveShadow = false;
-          }
-          mesh.name = "normal";
+  let normalMeshes: THREE.Mesh[] = [];
+  let transparentMeshes: THREE.Mesh[] = [];
+  let carpetMeshes: THREE.Mesh[] = [];
+  geometries.normal.forEach((group) => {
+    if (group.length > 0) {
+      let geometry = BufferGeometryUtils.mergeGeometries(group, false);
+      if (geometry !== null) {
+        let mesh = new THREE.Mesh(
+          geometry,
+          new THREE.MeshPhongMaterial({
+            vertexColors: true,
+            side: THREE.DoubleSide,
+            specular: materialSpecular,
+            shininess: materialShininess
+          })
+        );
+        normalMeshes.push(mesh);
+        if (mode === "cinematic") {
+          mesh.castShadow = true;
+          mesh.receiveShadow = false;
         }
+        mesh.name = "normal";
       }
-    });
-    geometries.transparent.forEach((group) => {
-      if (group.length > 0) {
-        let geometry = BufferGeometryUtils.mergeGeometries(group, false);
-        if (geometry !== null) {
-          let mesh = new THREE.Mesh(
-            geometry,
-            new THREE.MeshPhongMaterial({
-              vertexColors: true,
-              side: THREE.DoubleSide,
-              specular: materialSpecular,
-              shininess: materialShininess,
-              transparent: true,
-              opacity: 0.2,
-              depthWrite: false
-            })
-          );
-          transparentMeshes.push(mesh);
-          if (mode === "cinematic") {
-            mesh.castShadow = true;
-            mesh.receiveShadow = false;
-          }
-          mesh.name = "transparent";
-        }
-      }
-    });
-    geometries.carpet.forEach((group) => {
-      if (group.length > 0) {
-        let geometry = BufferGeometryUtils.mergeGeometries(group, false);
-        if (geometry !== null) {
-          let mesh = new THREE.Mesh(
-            geometry,
-            new THREE.MeshPhongMaterial({
-              vertexColors: true,
-              side: THREE.DoubleSide,
-              specular: materialSpecular,
-              shininess: 0
-            })
-          );
-          carpetMeshes.push(mesh);
-          if (mode === "cinematic") {
-            mesh.castShadow = false;
-            mesh.receiveShadow = true;
-          }
-          mesh.name = "carpet";
-        }
-      }
-    });
-    disposeObject(object);
-    resolve({
-      normal: normalMeshes,
-      transparent: transparentMeshes,
-      carpet: carpetMeshes
-    });
+    }
   });
+  geometries.transparent.forEach((group) => {
+    if (group.length > 0) {
+      let geometry = BufferGeometryUtils.mergeGeometries(group, false);
+      if (geometry !== null) {
+        let mesh = new THREE.Mesh(
+          geometry,
+          new THREE.MeshPhongMaterial({
+            vertexColors: true,
+            side: THREE.DoubleSide,
+            specular: materialSpecular,
+            shininess: materialShininess,
+            transparent: true,
+            opacity: 0.2,
+            depthWrite: false
+          })
+        );
+        transparentMeshes.push(mesh);
+        if (mode === "cinematic") {
+          mesh.castShadow = true;
+          mesh.receiveShadow = false;
+        }
+        mesh.name = "transparent";
+      }
+    }
+  });
+  geometries.carpet.forEach((group) => {
+    if (group.length > 0) {
+      let geometry = BufferGeometryUtils.mergeGeometries(group, false);
+      if (geometry !== null) {
+        let mesh = new THREE.Mesh(
+          geometry,
+          new THREE.MeshPhongMaterial({
+            vertexColors: true,
+            side: THREE.DoubleSide,
+            specular: materialSpecular,
+            shininess: 0
+          })
+        );
+        carpetMeshes.push(mesh);
+        if (mode === "cinematic") {
+          mesh.castShadow = false;
+          mesh.receiveShadow = true;
+        }
+        mesh.name = "carpet";
+      }
+    }
+  });
+  disposeObject(object);
+  return {
+    normal: normalMeshes,
+    transparent: transparentMeshes,
+    carpet: carpetMeshes
+  };
 }
 
 function getGeometries(

--- a/src/shared/renderers/field3d/objectManagers/AxesManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/AxesManager.ts
@@ -27,12 +27,11 @@ export default class AxesManager extends ObjectManager<Field3dRendererCommand_Ax
 
     let axes = makeAxesTemplate(this.materialSpecular, this.materialShininess);
     axes.scale.set(0.25, 0.25, 0.25);
-    optimizeGeometries(axes, this.mode, this.materialSpecular, this.materialShininess, false).then((result) => {
-      let axesMerged = result.normal[0];
-      if (axesMerged !== null) {
-        this.instances = new ResizableInstancedMesh(root, [axesMerged]);
-      }
-    });
+    const result = optimizeGeometries(axes, this.mode, this.materialSpecular, this.materialShininess, false);
+    let axesMerged = result.normal[0];
+    if (axesMerged !== null) {
+      this.instances = new ResizableInstancedMesh(root, [axesMerged]);
+    }
   }
 
   dispose(): void {

--- a/src/shared/renderers/field3d/objectManagers/RobotManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/RobotManager.ts
@@ -170,19 +170,11 @@ export default class RobotManager extends ObjectManager<
           const urlTransformer: (path: string) => string = (url) => "/asset?path=" + encodeURIComponent(url);
           const gltfLoader = new GLTFLoader();
           Promise.all([
-            new Promise((resolve) => {
-              gltfLoader.load(urlTransformer(robotConfig.path), resolve);
-            }),
-            ...robotConfig.components.map(
-              (_, index) =>
-                new Promise((resolve) => {
-                  gltfLoader.load(
-                    urlTransformer(robotConfig.path.slice(0, -4) + "_" + index.toString() + ".glb"),
-                    resolve
-                  );
-                })
+            gltfLoader.loadAsync(urlTransformer(robotConfig.path)),
+            ...robotConfig.components.map((_, index) =>
+              gltfLoader.loadAsync(urlTransformer(robotConfig.path.slice(0, -4) + "_" + index.toString() + ".glb"))
             )
-          ]).then(async (gltfs) => {
+          ]).then((gltfs) => {
             if (loadingCounter !== this.loadingCounter) {
               // Model was switched, throw away the data :(
               return;

--- a/src/shared/renderers/field3d/workers/loadField.ts
+++ b/src/shared/renderers/field3d/workers/loadField.ts
@@ -34,16 +34,11 @@ self.onmessage = (event) => {
 
   const gltfLoader = new GLTFLoader();
   Promise.all([
-    new Promise((resolve) => {
-      gltfLoader.load(fieldConfig.path, resolve);
-    }),
-    ...fieldConfig.gamePieces.map(
-      (_, index) =>
-        new Promise((resolve) => {
-          gltfLoader.load(fieldConfig.path.slice(0, -4) + "_" + index.toString() + ".glb", resolve);
-        })
+    gltfLoader.loadAsync(fieldConfig.path),
+    ...fieldConfig.gamePieces.map((_, index) =>
+      gltfLoader.loadAsync(fieldConfig.path.slice(0, -4) + "_" + index.toString() + ".glb")
     )
-  ]).then(async (gltfs) => {
+  ]).then((gltfs) => {
     let gltfScenes = (gltfs as GLTF[]).map((gltf) => gltf.scene);
     if (fieldConfig === undefined) return;
     let loadCount = 0;
@@ -67,7 +62,7 @@ self.onmessage = (event) => {
 
         stagedPieces.rotation.setFromQuaternion(rotationSequenceToQuaternion(fieldConfig.rotations));
         stagedPieces.position.set(...fieldConfig.position);
-        let fieldStagedPiecesMeshes = await optimizeGeometries(
+        let fieldStagedPiecesMeshes = optimizeGeometries(
           stagedPieces,
           mode,
           materialSpecular,
@@ -83,7 +78,7 @@ self.onmessage = (event) => {
 
         scene.rotation.setFromQuaternion(rotationSequenceToQuaternion(fieldConfig.rotations));
         scene.position.set(...fieldConfig.position);
-        let fieldMeshes = await optimizeGeometries(
+        let fieldMeshes = optimizeGeometries(
           scene,
           mode,
           materialSpecular,
@@ -101,8 +96,13 @@ self.onmessage = (event) => {
         let gamePieceConfig = fieldConfig.gamePieces[index - 1];
         scene.rotation.setFromQuaternion(rotationSequenceToQuaternion(gamePieceConfig.rotations));
         scene.position.set(...gamePieceConfig.position);
-        let meshes = (
-          await optimizeGeometries(scene, mode, materialSpecular, materialShininess, false, fieldConfig.isFTC)
+        let meshes = optimizeGeometries(
+          scene,
+          mode,
+          materialSpecular,
+          materialShininess,
+          false,
+          fieldConfig.isFTC
         ).normal;
         if (meshes.length > 0) {
           fieldPieces[gamePieceConfig.name] = meshes[0];

--- a/src/shared/renderers/field3d/workers/loadRobot.ts
+++ b/src/shared/renderers/field3d/workers/loadRobot.ts
@@ -33,16 +33,11 @@ self.onmessage = (event) => {
 
   const gltfLoader = new GLTFLoader();
   Promise.all([
-    new Promise((resolve) => {
-      gltfLoader.load(robotConfig.path, resolve);
-    }),
-    ...robotConfig.components.map(
-      (_, index) =>
-        new Promise((resolve) => {
-          gltfLoader.load(robotConfig.path.slice(0, -4) + "_" + index.toString() + ".glb", resolve);
-        })
+    gltfLoader.loadAsync(robotConfig.path),
+    ...robotConfig.components.map((_, index) =>
+      gltfLoader.loadAsync(robotConfig.path.slice(0, -4) + "_" + index.toString() + ".glb")
     )
-  ]).then(async (gltfs) => {
+  ]).then((gltfs) => {
     let gltfScenes = (gltfs as GLTF[]).map((gltf) => gltf.scene);
     for (let index = 0; index < gltfScenes.length; index++) {
       let scene = gltfScenes[index];
@@ -51,7 +46,7 @@ self.onmessage = (event) => {
         scene.position.set(...robotConfig!.position);
       }
 
-      let optimized = await optimizeGeometries(
+      let optimized = optimizeGeometries(
         scene,
         mode,
         materialSpecular,

--- a/src/xrClient/XRRenderer.ts
+++ b/src/xrClient/XRRenderer.ts
@@ -584,14 +584,9 @@ export default class XRRenderer {
         const loader = new GLTFLoader();
         const urlTransformer: (path: string) => string = (url) => "/asset?path=" + encodeURIComponent(url);
         Promise.all([
-          new Promise((resolve) => {
-            loader.load(urlTransformer(fieldConfig.path), resolve);
-          }),
-          ...fieldConfig.gamePieces.map(
-            (_, index) =>
-              new Promise((resolve) => {
-                loader.load(urlTransformer(fieldConfig.path.slice(0, -4) + "_" + index.toString() + ".glb"), resolve);
-              })
+          loader.loadAsync(urlTransformer(fieldConfig.path)),
+          ...fieldConfig.gamePieces.map((_, index) =>
+            loader.loadAsync(urlTransformer(fieldConfig.path.slice(0, -4) + "_" + index.toString() + ".glb"))
           )
         ]).then((gltfs) => {
           let gltfScenes = (gltfs as GLTF[]).map((gltf) => gltf.scene);
@@ -685,8 +680,12 @@ export default class XRRenderer {
               let gamePieceConfig = fieldConfig.gamePieces[index - 1];
               scene.rotation.setFromQuaternion(rotationSequenceToQuaternion(gamePieceConfig.rotations));
               scene.position.set(...gamePieceConfig.position);
-              let meshes = (
-                await optimizeGeometries(scene, "standard", this.MATERIAL_SPECULAR, this.MATERIAL_SHININESS, false)
+              let meshes = optimizeGeometries(
+                scene,
+                "standard",
+                this.MATERIAL_SPECULAR,
+                this.MATERIAL_SHININESS,
+                false
               ).normal;
               if (meshes.length > 0) {
                 newFieldPieces[gamePieceConfig.name] = meshes[0];


### PR DESCRIPTION
There are quite a few functions that specify `async` but don't await anything, use Promises to wrap callback-based functions when async functions already exist, or use the Promise API in an async function where it's unnecessary. This PR cleans up those usages.