### PR TITLE
Fix parsing of SwerveModuleVelocity in current and legacy formats.

### DIFF
--- a/docs/docs/tab-reference/swerve.md
+++ b/docs/docs/tab-reference/swerve.md
@@ -76,6 +76,11 @@ Logger.recordOutput("MyStates", states);
 </TabItem>
 </Tabs>
 
+:::note
+In 2027, this data structure was renamed from `SwerveModuleState` to `SwerveModuleVelocity`.
+For log files created before WPILib 2027 and Systemcore, legacy `SwerveModuleState` types are still supported for visualization.
+:::
+
 ## Configuration
 
 The following configuration options are available:

--- a/src/hub/SourceList.ts
+++ b/src/hub/SourceList.ts
@@ -1079,7 +1079,7 @@ export default class SourceList {
                 moduleVelocities.forEach((state) => {
                   poseStrings.push(
                     "\u03bd: " +
-                      state.speed.toFixed(2) +
+                      state.velocity.toFixed(2) +
                       "m/s, \u03b8: " +
                       Units.convert(state.angle, "radians", "degrees").toFixed(2) +
                       "\u00b0"

--- a/src/hub/controllers/SwerveController.ts
+++ b/src/hub/controllers/SwerveController.ts
@@ -138,7 +138,7 @@ export default class SwerveController implements TabController {
         );
         moduleVelocities.forEach((state) => {
           // Normalize
-          state.speed = clampValue(state.speed / Number(this.MAX_SPEED.value), -1, 1);
+          state.velocity = clampValue(state.velocity / Number(this.MAX_SPEED.value), -1, 1);
         });
         commandModuleVelocities.push({
           values: moduleVelocities,

--- a/src/shared/geometry.ts
+++ b/src/shared/geometry.ts
@@ -54,7 +54,7 @@ export type PoseAnnotations = {
   visionSize?: string;
 };
 
-export type ModuleVelocity = { speed: number; angle: Rotation2d };
+export type ModuleVelocity = { velocity: number; angle: Rotation2d };
 export type RobotVelocities = { vx: number; vy: number; omega: number };
 
 export const APRIL_TAG_36H11_COUNT = 587;
@@ -619,9 +619,24 @@ export function grabModuleVelocities(
 ): ModuleVelocity[] {
   let velocities: ModuleVelocity[] = [];
   let length = getOrDefault(log, key + "/length", LoggableType.Number, timestamp, 0, uuid);
+
+  let velocityKey = "velocity";
+
+  // Legacy type support for pre-2027 module velocities.
+  if (log.getStructuredType(key) === "SwerveModuleState[]") {
+    velocityKey = "speed";
+  }
+
   for (let i = 0; i < length; i++) {
     velocities.push({
-      speed: getOrDefault(log, key + "/" + i.toString() + "/speed", LoggableType.Number, timestamp, 0, uuid),
+      velocity: getOrDefault(
+        log,
+        key + "/" + i.toString() + `/${velocityKey}`,
+        LoggableType.Number,
+        timestamp,
+        0,
+        uuid
+      ),
       angle: getOrDefault(log, key + "/" + i.toString() + "/angle/value", LoggableType.Number, timestamp, 0, uuid)
     });
   }

--- a/src/shared/geometry.ts
+++ b/src/shared/geometry.ts
@@ -631,7 +631,7 @@ export function grabModuleVelocities(
     velocities.push({
       velocity: getOrDefault(
         log,
-        key + "/" + i.toString() + `/${velocityKey}`,
+        key + "/" + i.toString() + "/" + velocityKey,
         LoggableType.Number,
         timestamp,
         0,

--- a/src/shared/renderers/Field2dRenderer.ts
+++ b/src/shared/renderers/Field2dRenderer.ts
@@ -224,10 +224,10 @@ export default class Field2dRenderer implements TabRenderer {
           context.strokeStyle = color;
 
           // Draw speed
-          if (Math.abs(state.speed) <= 0.001) return;
-          let vectorSpeed = state.speed / 5;
+          if (Math.abs(state.velocity) <= 0.001) return;
+          let vectorSpeed = state.velocity / 5;
           let vectorRotation = fullRotation;
-          if (state.speed < 0) {
+          if (state.velocity < 0) {
             vectorSpeed *= -1;
             vectorRotation += Math.PI;
           }

--- a/src/shared/renderers/SwerveRenderer.ts
+++ b/src/shared/renderers/SwerveRenderer.ts
@@ -161,10 +161,10 @@ export default class SwerveRenderer implements TabRenderer {
         context.fill();
 
         // Draw speed
-        if (Math.abs(state.speed) <= 0.001) return;
-        let vectorSpeed = state.speed;
+        if (Math.abs(state.velocity) <= 0.001) return;
+        let vectorSpeed = state.velocity;
         let vectorRotation = fullRotation;
-        if (state.speed < 0) {
+        if (state.velocity < 0) {
           vectorSpeed *= -1;
           vectorRotation += Math.PI;
         }

--- a/src/shared/renderers/field3d/objectManagers/RobotManager.ts
+++ b/src/shared/renderers/field3d/objectManagers/RobotManager.ts
@@ -553,10 +553,10 @@ export default class RobotManager extends ObjectManager<
           context.lineJoin = "round";
 
           // Draw speed
-          if (Math.abs(state.speed) <= 0.001) return;
-          let vectorSpeed = state.speed / 5;
+          if (Math.abs(state.velocity) <= 0.001) return;
+          let vectorSpeed = state.velocity / 5;
           let vectorRotation = state.angle;
-          if (state.speed < 0) {
+          if (state.velocity < 0) {
             vectorSpeed *= -1;
             vectorRotation += Math.PI;
           }


### PR DESCRIPTION
Resolves #552.

The 2027 "SwerveModuleVelocity" also renames its value to "velocity" rather than "speed". Meaning that we will need to handle both differently.

This PR fixes this, while maintaining support for the legacy format based on the type. Also renames the internal name from `speed` to `velocity` for consistency. It also adds a quick note to documentation that states this backwards-compatibility.

I have tested this in both legacy and 2027 log files, and swerve module velocities render properly in both:

<img width="1508" height="895" alt="image" src="https://github.com/user-attachments/assets/efe03c18-cd1e-422a-a461-f65890db2daa" />

<img width="1383" height="758" alt="image" src="https://github.com/user-attachments/assets/bec90080-f6a1-42a8-9b00-c0f7f090cbe6" />
